### PR TITLE
Manually remove use of bindgen at build-time.

### DIFF
--- a/library/neptune-triton/Cargo.toml
+++ b/library/neptune-triton/Cargo.toml
@@ -9,7 +9,6 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.51.0"
 cc = "1.0"
 
 [features]

--- a/library/neptune-triton/build.rs
+++ b/library/neptune-triton/build.rs
@@ -1,16 +1,7 @@
-extern crate bindgen;
 extern crate cc;
-
-use std::env;
-use std::path::PathBuf;
 
 fn main() {
     // Sequential C support
-    #[cfg(feature = "sequential_c")]
-    let bindings = bindgen::Builder::default()
-        .header("./lib/a.h")
-        .generate()
-        .expect("Unable to generate bindings");
     #[cfg(feature = "sequential_c")]
     cc::Build::new()
         .file("./lib/a.c")
@@ -20,12 +11,6 @@ fn main() {
         .compile("a");
 
     // CUDA support
-    #[cfg(feature = "cuda")]
-    let bindings = bindgen::Builder::default()
-        .header("./lib/a.h")
-        .clang_arg("-I/opt/cuda/include")
-        .generate()
-        .expect("Unable to generate bindings");
     #[cfg(feature = "cuda")]
     cc::Build::new()
         .file("./lib/a.c")
@@ -46,14 +31,6 @@ fn main() {
     // OpenCL support
     // FIXME: bindgen can't find OpenCL/cl.h on macos.
 
-    #[cfg(all(feature = "opencl", target_os = "macos"))]
-    println!("cargo:rustc-link-lib=framework=OpenCL");
-
-    #[cfg(all(feature = "opencl", not(target_os = "macos")))]
-    let bindings = bindgen::Builder::default()
-        .header("./lib/a.h")
-        .generate()
-        .expect("Unable to generate bindings");
     #[cfg(feature = "opencl")]
     {
         #[cfg(not(target_os = "macos"))]
@@ -77,10 +54,4 @@ fn main() {
                 .compile("a");
         }
     }
-
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    #[cfg(not(all(feature = "opencl", target_os = "macos")))]
-    bindings
-        .write_to_file(out_path.join("bindings.rs"))
-        .expect("Couldn't write bindings!");
 }


### PR DESCRIPTION
Until we figure out the best way to deal with generating bindings on MacOS, I'm going to avoid more churn on `genfut` code generation. Meanwhile, the code is stable, and this patch will get us what we want downstream.