### PR TITLE
Support strengthened Poseidon.

### DIFF
--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -9,4 +9,4 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-genfut = { version = "0.1.5", default-features = false, features = ["opencl"] }
+genfut = { version = "0.1.6", default-features = false, features = ["opencl"] }

--- a/library/neptune-triton/Cargo.toml
+++ b/library/neptune-triton/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "neptune-triton"
 description = "GPU implementation of neptune-compatible Poseidon hashing."
-version = "0.2.2"
+version = "1.0.0"
 authors = ["porcuquine@gmail.com"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/library/neptune-triton/lib/a.h
+++ b/library/neptune-triton/lib/a.h
@@ -169,6 +169,15 @@ int futhark_free_opaque_p2_state(struct futhark_context *ctx,
 struct futhark_opaque_p8_state ;
 int futhark_free_opaque_p8_state(struct futhark_context *ctx,
                                  struct futhark_opaque_p8_state *obj);
+struct futhark_opaque_s11_state ;
+int futhark_free_opaque_s11_state(struct futhark_context *ctx,
+                                  struct futhark_opaque_s11_state *obj);
+struct futhark_opaque_s2_state ;
+int futhark_free_opaque_s2_state(struct futhark_context *ctx,
+                                 struct futhark_opaque_s2_state *obj);
+struct futhark_opaque_s8_state ;
+int futhark_free_opaque_s8_state(struct futhark_context *ctx,
+                                 struct futhark_opaque_s8_state *obj);
 struct futhark_opaque_t8_64m_state ;
 int futhark_free_opaque_t8_64m_state(struct futhark_context *ctx,
                                      struct futhark_opaque_t8_64m_state *obj);
@@ -183,6 +192,21 @@ int futhark_entry_build_tree8_64m(struct futhark_context *ctx,
                                   struct futhark_u64_2d **out0, const
                                   struct futhark_opaque_t8_64m_state *in0, const
                                   struct futhark_u64_1d *in1);
+int futhark_entry_mbatch_hash11s(struct futhark_context *ctx,
+                                 struct futhark_u64_2d **out0,
+                                 struct futhark_opaque_s11_state **out1, const
+                                 struct futhark_opaque_s11_state *in0, const
+                                 struct futhark_u64_1d *in1);
+int futhark_entry_mbatch_hash8s(struct futhark_context *ctx,
+                                struct futhark_u64_2d **out0,
+                                struct futhark_opaque_s8_state **out1, const
+                                struct futhark_opaque_s8_state *in0, const
+                                struct futhark_u64_1d *in1);
+int futhark_entry_mbatch_hash2s(struct futhark_context *ctx,
+                                struct futhark_u64_2d **out0,
+                                struct futhark_opaque_s2_state **out1, const
+                                struct futhark_opaque_s2_state *in0, const
+                                struct futhark_u64_1d *in1);
 int futhark_entry_mbatch_hash11(struct futhark_context *ctx,
                                 struct futhark_u64_2d **out0,
                                 struct futhark_opaque_p11_state **out1, const
@@ -210,6 +234,27 @@ int futhark_entry_init_t8_64m(struct futhark_context *ctx,
                               struct futhark_u64_3d *in2, const
                               struct futhark_u64_3d *in3, const
                               struct futhark_u64_3d *in4);
+int futhark_entry_init11s(struct futhark_context *ctx,
+                          struct futhark_opaque_s11_state **out0, const
+                          struct futhark_u64_1d *in0, const
+                          struct futhark_u64_2d *in1, const
+                          struct futhark_u64_3d *in2, const
+                          struct futhark_u64_3d *in3, const
+                          struct futhark_u64_3d *in4);
+int futhark_entry_init8s(struct futhark_context *ctx,
+                         struct futhark_opaque_s8_state **out0, const
+                         struct futhark_u64_1d *in0, const
+                         struct futhark_u64_2d *in1, const
+                         struct futhark_u64_3d *in2, const
+                         struct futhark_u64_3d *in3, const
+                         struct futhark_u64_3d *in4);
+int futhark_entry_init2s(struct futhark_context *ctx,
+                         struct futhark_opaque_s2_state **out0, const
+                         struct futhark_u64_1d *in0, const
+                         struct futhark_u64_2d *in1, const
+                         struct futhark_u64_3d *in2, const
+                         struct futhark_u64_3d *in3, const
+                         struct futhark_u64_3d *in4);
 int futhark_entry_init11(struct futhark_context *ctx,
                          struct futhark_opaque_p11_state **out0, const
                          struct futhark_u64_1d *in0, const

--- a/library/neptune-triton/src/arrays.rs
+++ b/library/neptune-triton/src/arrays.rs
@@ -5,7 +5,7 @@ use crate::{Error, Result};
 pub(crate) trait FutharkType {
     type RustType: Default;
     const DIM: usize;
-
+    
     unsafe fn shape<C>(ctx: C, ptr: *const Self) -> *mut i64
     where
         C: Into<*mut bindings::futhark_context>;
@@ -20,205 +20,205 @@ pub(crate) trait FutharkType {
 use crate::bindings::*;
 
 impl futhark_i64_1d {
-    unsafe fn new<C>(ctx: C, arr: &[i64], dim: &[i64]) -> *const Self
-    where
-        C: Into<*mut bindings::futhark_context>,
-    {
-        let ctx = ctx.into();
-        bindings::futhark_new_i64_1d(ctx, arr.as_ptr() as *mut i64, dim[0])
-    }
+   unsafe fn new<C>(ctx: C, arr: &[i64], dim: &[i64]) -> *const Self
+   where C: Into<*mut bindings::futhark_context>
+   {
+     let ctx = ctx.into();
+     bindings::futhark_new_i64_1d(
+       ctx,
+       arr.as_ptr() as *mut i64,
+       dim[0],
+)
+     }
 }
 
 impl FutharkType for futhark_i64_1d {
-    type RustType = i64;
-    const DIM: usize = 1;
+   type RustType = i64;
+   const DIM: usize = 1;
 
     unsafe fn shape<C>(ctx: C, ptr: *const bindings::futhark_i64_1d) -> *mut i64
-    where
-        C: Into<*mut bindings::futhark_context>,
+    where C: Into<*mut bindings::futhark_context>
     {
         let ctx = ctx.into();
         bindings::futhark_shape_i64_1d(ctx, ptr as *mut bindings::futhark_i64_1d)
     }
     unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType)
-    where
-        C: Into<*mut bindings::futhark_context>,
+    where C: Into<*mut bindings::futhark_context>
     {
         let ctx = ctx.into();
         bindings::futhark_values_i64_1d(ctx, ptr, dst);
     }
     unsafe fn free<C>(ctx: C, ptr: *mut Self)
-    where
-        C: Into<*mut bindings::futhark_context>,
+    where C: Into<*mut bindings::futhark_context>
     {
         let ctx = ctx.into();
         bindings::futhark_free_i64_1d(ctx, ptr);
-    }
-}
+    }}
 
 impl futhark_i64_2d {
-    unsafe fn new<C>(ctx: C, arr: &[i64], dim: &[i64]) -> *const Self
-    where
-        C: Into<*mut bindings::futhark_context>,
-    {
-        let ctx = ctx.into();
-        bindings::futhark_new_i64_2d(ctx, arr.as_ptr() as *mut i64, dim[0], dim[1])
-    }
+   unsafe fn new<C>(ctx: C, arr: &[i64], dim: &[i64]) -> *const Self
+   where C: Into<*mut bindings::futhark_context>
+   {
+     let ctx = ctx.into();
+     bindings::futhark_new_i64_2d(
+       ctx,
+       arr.as_ptr() as *mut i64,
+       dim[0],
+dim[1],
+)
+     }
 }
 
 impl FutharkType for futhark_i64_2d {
-    type RustType = i64;
-    const DIM: usize = 2;
+   type RustType = i64;
+   const DIM: usize = 2;
 
     unsafe fn shape<C>(ctx: C, ptr: *const bindings::futhark_i64_2d) -> *mut i64
-    where
-        C: Into<*mut bindings::futhark_context>,
+    where C: Into<*mut bindings::futhark_context>
     {
         let ctx = ctx.into();
         bindings::futhark_shape_i64_2d(ctx, ptr as *mut bindings::futhark_i64_2d)
     }
     unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType)
-    where
-        C: Into<*mut bindings::futhark_context>,
+    where C: Into<*mut bindings::futhark_context>
     {
         let ctx = ctx.into();
         bindings::futhark_values_i64_2d(ctx, ptr, dst);
     }
     unsafe fn free<C>(ctx: C, ptr: *mut Self)
-    where
-        C: Into<*mut bindings::futhark_context>,
+    where C: Into<*mut bindings::futhark_context>
     {
         let ctx = ctx.into();
         bindings::futhark_free_i64_2d(ctx, ptr);
-    }
-}
+    }}
 
 impl futhark_u64_1d {
-    unsafe fn new<C>(ctx: C, arr: &[u64], dim: &[i64]) -> *const Self
-    where
-        C: Into<*mut bindings::futhark_context>,
-    {
-        let ctx = ctx.into();
-        bindings::futhark_new_u64_1d(ctx, arr.as_ptr() as *mut u64, dim[0])
-    }
+   unsafe fn new<C>(ctx: C, arr: &[u64], dim: &[i64]) -> *const Self
+   where C: Into<*mut bindings::futhark_context>
+   {
+     let ctx = ctx.into();
+     bindings::futhark_new_u64_1d(
+       ctx,
+       arr.as_ptr() as *mut u64,
+       dim[0],
+)
+     }
 }
 
 impl FutharkType for futhark_u64_1d {
-    type RustType = u64;
-    const DIM: usize = 1;
+   type RustType = u64;
+   const DIM: usize = 1;
 
     unsafe fn shape<C>(ctx: C, ptr: *const bindings::futhark_u64_1d) -> *mut i64
-    where
-        C: Into<*mut bindings::futhark_context>,
+    where C: Into<*mut bindings::futhark_context>
     {
         let ctx = ctx.into();
         bindings::futhark_shape_u64_1d(ctx, ptr as *mut bindings::futhark_u64_1d)
     }
     unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType)
-    where
-        C: Into<*mut bindings::futhark_context>,
+    where C: Into<*mut bindings::futhark_context>
     {
         let ctx = ctx.into();
         bindings::futhark_values_u64_1d(ctx, ptr, dst);
     }
     unsafe fn free<C>(ctx: C, ptr: *mut Self)
-    where
-        C: Into<*mut bindings::futhark_context>,
+    where C: Into<*mut bindings::futhark_context>
     {
         let ctx = ctx.into();
         bindings::futhark_free_u64_1d(ctx, ptr);
-    }
-}
+    }}
 
 impl futhark_u64_2d {
-    unsafe fn new<C>(ctx: C, arr: &[u64], dim: &[i64]) -> *const Self
-    where
-        C: Into<*mut bindings::futhark_context>,
-    {
-        let ctx = ctx.into();
-        bindings::futhark_new_u64_2d(ctx, arr.as_ptr() as *mut u64, dim[0], dim[1])
-    }
+   unsafe fn new<C>(ctx: C, arr: &[u64], dim: &[i64]) -> *const Self
+   where C: Into<*mut bindings::futhark_context>
+   {
+     let ctx = ctx.into();
+     bindings::futhark_new_u64_2d(
+       ctx,
+       arr.as_ptr() as *mut u64,
+       dim[0],
+dim[1],
+)
+     }
 }
 
 impl FutharkType for futhark_u64_2d {
-    type RustType = u64;
-    const DIM: usize = 2;
+   type RustType = u64;
+   const DIM: usize = 2;
 
     unsafe fn shape<C>(ctx: C, ptr: *const bindings::futhark_u64_2d) -> *mut i64
-    where
-        C: Into<*mut bindings::futhark_context>,
+    where C: Into<*mut bindings::futhark_context>
     {
         let ctx = ctx.into();
         bindings::futhark_shape_u64_2d(ctx, ptr as *mut bindings::futhark_u64_2d)
     }
     unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType)
-    where
-        C: Into<*mut bindings::futhark_context>,
+    where C: Into<*mut bindings::futhark_context>
     {
         let ctx = ctx.into();
         bindings::futhark_values_u64_2d(ctx, ptr, dst);
     }
     unsafe fn free<C>(ctx: C, ptr: *mut Self)
-    where
-        C: Into<*mut bindings::futhark_context>,
+    where C: Into<*mut bindings::futhark_context>
     {
         let ctx = ctx.into();
         bindings::futhark_free_u64_2d(ctx, ptr);
-    }
-}
+    }}
 
 impl futhark_u64_3d {
-    unsafe fn new<C>(ctx: C, arr: &[u64], dim: &[i64]) -> *const Self
-    where
-        C: Into<*mut bindings::futhark_context>,
-    {
-        let ctx = ctx.into();
-        bindings::futhark_new_u64_3d(ctx, arr.as_ptr() as *mut u64, dim[0], dim[1], dim[2])
-    }
+   unsafe fn new<C>(ctx: C, arr: &[u64], dim: &[i64]) -> *const Self
+   where C: Into<*mut bindings::futhark_context>
+   {
+     let ctx = ctx.into();
+     bindings::futhark_new_u64_3d(
+       ctx,
+       arr.as_ptr() as *mut u64,
+       dim[0],
+dim[1],
+dim[2],
+)
+     }
 }
 
 impl FutharkType for futhark_u64_3d {
-    type RustType = u64;
-    const DIM: usize = 3;
+   type RustType = u64;
+   const DIM: usize = 3;
 
     unsafe fn shape<C>(ctx: C, ptr: *const bindings::futhark_u64_3d) -> *mut i64
-    where
-        C: Into<*mut bindings::futhark_context>,
+    where C: Into<*mut bindings::futhark_context>
     {
         let ctx = ctx.into();
         bindings::futhark_shape_u64_3d(ctx, ptr as *mut bindings::futhark_u64_3d)
     }
     unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType)
-    where
-        C: Into<*mut bindings::futhark_context>,
+    where C: Into<*mut bindings::futhark_context>
     {
         let ctx = ctx.into();
         bindings::futhark_values_u64_3d(ctx, ptr, dst);
     }
     unsafe fn free<C>(ctx: C, ptr: *mut Self)
-    where
-        C: Into<*mut bindings::futhark_context>,
+    where C: Into<*mut bindings::futhark_context>
     {
         let ctx = ctx.into();
         bindings::futhark_free_u64_3d(ctx, ptr);
-    }
-}
+    }}
 #[derive(Debug)]
 pub struct Array_i64_1d {
     ptr: *const futhark_i64_1d,
     ctx: *mut bindings::futhark_context,
 }
 
+
 impl Array_i64_1d {
     pub(crate) unsafe fn as_raw(&self) -> *const futhark_i64_1d {
-        self.ptr
+         self.ptr
     }
 
     pub(crate) unsafe fn as_raw_mut(&self) -> *mut futhark_i64_1d {
-        self.ptr as *mut futhark_i64_1d
+         self.ptr as *mut futhark_i64_1d
     }
     pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const futhark_i64_1d) -> Self
-    where
+        where
         T: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
@@ -250,20 +250,23 @@ impl Array_i64_1d {
             Ok(Array_i64_1d { ptr, ctx })
         }
     }
-
-    pub fn to_vec(&self) -> (Vec<i64>, Vec<i64>) {
+    
+    pub fn to_vec(&self) -> (Vec<i64>, Vec<i64>)
+    {
         let ctx = self.ctx;
         unsafe {
             futhark_context_sync(ctx);
             let shape = Self::shape(ctx, self.as_raw());
             let elems = shape.iter().fold(1, |acc, e| acc * e) as usize;
-            let mut buffer: Vec<i64> = vec![i64::default(); elems];
+            let mut buffer: Vec<i64> =
+                vec![i64::default(); elems];
             let cint = futhark_i64_1d::values(ctx, self.as_raw_mut(), buffer.as_mut_ptr());
             (buffer, shape.to_owned())
         }
     }
 
-    pub(crate) unsafe fn free_array(&mut self) {
+    pub(crate) unsafe fn free_array(&mut self)
+    {
         futhark_i64_1d::free(self.ctx, self.as_raw_mut());
     }
 }
@@ -282,16 +285,17 @@ pub struct Array_i64_2d {
     ctx: *mut bindings::futhark_context,
 }
 
+
 impl Array_i64_2d {
     pub(crate) unsafe fn as_raw(&self) -> *const futhark_i64_2d {
-        self.ptr
+         self.ptr
     }
 
     pub(crate) unsafe fn as_raw_mut(&self) -> *mut futhark_i64_2d {
-        self.ptr as *mut futhark_i64_2d
+         self.ptr as *mut futhark_i64_2d
     }
     pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const futhark_i64_2d) -> Self
-    where
+        where
         T: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
@@ -323,20 +327,23 @@ impl Array_i64_2d {
             Ok(Array_i64_2d { ptr, ctx })
         }
     }
-
-    pub fn to_vec(&self) -> (Vec<i64>, Vec<i64>) {
+    
+    pub fn to_vec(&self) -> (Vec<i64>, Vec<i64>)
+    {
         let ctx = self.ctx;
         unsafe {
             futhark_context_sync(ctx);
             let shape = Self::shape(ctx, self.as_raw());
             let elems = shape.iter().fold(1, |acc, e| acc * e) as usize;
-            let mut buffer: Vec<i64> = vec![i64::default(); elems];
+            let mut buffer: Vec<i64> =
+                vec![i64::default(); elems];
             let cint = futhark_i64_2d::values(ctx, self.as_raw_mut(), buffer.as_mut_ptr());
             (buffer, shape.to_owned())
         }
     }
 
-    pub(crate) unsafe fn free_array(&mut self) {
+    pub(crate) unsafe fn free_array(&mut self)
+    {
         futhark_i64_2d::free(self.ctx, self.as_raw_mut());
     }
 }
@@ -355,16 +362,17 @@ pub struct Array_u64_1d {
     ctx: *mut bindings::futhark_context,
 }
 
+
 impl Array_u64_1d {
     pub(crate) unsafe fn as_raw(&self) -> *const futhark_u64_1d {
-        self.ptr
+         self.ptr
     }
 
     pub(crate) unsafe fn as_raw_mut(&self) -> *mut futhark_u64_1d {
-        self.ptr as *mut futhark_u64_1d
+         self.ptr as *mut futhark_u64_1d
     }
     pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const futhark_u64_1d) -> Self
-    where
+        where
         T: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
@@ -396,20 +404,23 @@ impl Array_u64_1d {
             Ok(Array_u64_1d { ptr, ctx })
         }
     }
-
-    pub fn to_vec(&self) -> (Vec<u64>, Vec<i64>) {
+    
+    pub fn to_vec(&self) -> (Vec<u64>, Vec<i64>)
+    {
         let ctx = self.ctx;
         unsafe {
             futhark_context_sync(ctx);
             let shape = Self::shape(ctx, self.as_raw());
             let elems = shape.iter().fold(1, |acc, e| acc * e) as usize;
-            let mut buffer: Vec<u64> = vec![u64::default(); elems];
+            let mut buffer: Vec<u64> =
+                vec![u64::default(); elems];
             let cint = futhark_u64_1d::values(ctx, self.as_raw_mut(), buffer.as_mut_ptr());
             (buffer, shape.to_owned())
         }
     }
 
-    pub(crate) unsafe fn free_array(&mut self) {
+    pub(crate) unsafe fn free_array(&mut self)
+    {
         futhark_u64_1d::free(self.ctx, self.as_raw_mut());
     }
 }
@@ -428,16 +439,17 @@ pub struct Array_u64_2d {
     ctx: *mut bindings::futhark_context,
 }
 
+
 impl Array_u64_2d {
     pub(crate) unsafe fn as_raw(&self) -> *const futhark_u64_2d {
-        self.ptr
+         self.ptr
     }
 
     pub(crate) unsafe fn as_raw_mut(&self) -> *mut futhark_u64_2d {
-        self.ptr as *mut futhark_u64_2d
+         self.ptr as *mut futhark_u64_2d
     }
     pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const futhark_u64_2d) -> Self
-    where
+        where
         T: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
@@ -469,20 +481,23 @@ impl Array_u64_2d {
             Ok(Array_u64_2d { ptr, ctx })
         }
     }
-
-    pub fn to_vec(&self) -> (Vec<u64>, Vec<i64>) {
+    
+    pub fn to_vec(&self) -> (Vec<u64>, Vec<i64>)
+    {
         let ctx = self.ctx;
         unsafe {
             futhark_context_sync(ctx);
             let shape = Self::shape(ctx, self.as_raw());
             let elems = shape.iter().fold(1, |acc, e| acc * e) as usize;
-            let mut buffer: Vec<u64> = vec![u64::default(); elems];
+            let mut buffer: Vec<u64> =
+                vec![u64::default(); elems];
             let cint = futhark_u64_2d::values(ctx, self.as_raw_mut(), buffer.as_mut_ptr());
             (buffer, shape.to_owned())
         }
     }
 
-    pub(crate) unsafe fn free_array(&mut self) {
+    pub(crate) unsafe fn free_array(&mut self)
+    {
         futhark_u64_2d::free(self.ctx, self.as_raw_mut());
     }
 }
@@ -501,16 +516,17 @@ pub struct Array_u64_3d {
     ctx: *mut bindings::futhark_context,
 }
 
+
 impl Array_u64_3d {
     pub(crate) unsafe fn as_raw(&self) -> *const futhark_u64_3d {
-        self.ptr
+         self.ptr
     }
 
     pub(crate) unsafe fn as_raw_mut(&self) -> *mut futhark_u64_3d {
-        self.ptr as *mut futhark_u64_3d
+         self.ptr as *mut futhark_u64_3d
     }
     pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const futhark_u64_3d) -> Self
-    where
+        where
         T: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
@@ -542,20 +558,23 @@ impl Array_u64_3d {
             Ok(Array_u64_3d { ptr, ctx })
         }
     }
-
-    pub fn to_vec(&self) -> (Vec<u64>, Vec<i64>) {
+    
+    pub fn to_vec(&self) -> (Vec<u64>, Vec<i64>)
+    {
         let ctx = self.ctx;
         unsafe {
             futhark_context_sync(ctx);
             let shape = Self::shape(ctx, self.as_raw());
             let elems = shape.iter().fold(1, |acc, e| acc * e) as usize;
-            let mut buffer: Vec<u64> = vec![u64::default(); elems];
+            let mut buffer: Vec<u64> =
+                vec![u64::default(); elems];
             let cint = futhark_u64_3d::values(ctx, self.as_raw_mut(), buffer.as_mut_ptr());
             (buffer, shape.to_owned())
         }
     }
 
-    pub(crate) unsafe fn free_array(&mut self) {
+    pub(crate) unsafe fn free_array(&mut self)
+    {
         futhark_u64_3d::free(self.ctx, self.as_raw_mut());
     }
 }
@@ -567,3 +586,6 @@ impl Drop for Array_u64_3d {
         }
     }
 }
+
+
+

--- a/library/neptune-triton/src/bindings.rs
+++ b/library/neptune-triton/src/bindings.rs
@@ -16435,6 +16435,39 @@ extern "C" {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+pub struct futhark_opaque_s11_state {
+    _unused: [u8; 0],
+}
+extern "C" {
+    pub fn futhark_free_opaque_s11_state(
+        ctx: *mut futhark_context,
+        obj: *mut futhark_opaque_s11_state,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct futhark_opaque_s2_state {
+    _unused: [u8; 0],
+}
+extern "C" {
+    pub fn futhark_free_opaque_s2_state(
+        ctx: *mut futhark_context,
+        obj: *mut futhark_opaque_s2_state,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct futhark_opaque_s8_state {
+    _unused: [u8; 0],
+}
+extern "C" {
+    pub fn futhark_free_opaque_s8_state(
+        ctx: *mut futhark_context,
+        obj: *mut futhark_opaque_s8_state,
+    ) -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct futhark_opaque_t8_64m_state {
     _unused: [u8; 0],
 }
@@ -16456,6 +16489,33 @@ extern "C" {
         ctx: *mut futhark_context,
         out0: *mut *mut futhark_u64_2d,
         in0: *const futhark_opaque_t8_64m_state,
+        in1: *const futhark_u64_1d,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn futhark_entry_mbatch_hash11s(
+        ctx: *mut futhark_context,
+        out0: *mut *mut futhark_u64_2d,
+        out1: *mut *mut futhark_opaque_s11_state,
+        in0: *const futhark_opaque_s11_state,
+        in1: *const futhark_u64_1d,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn futhark_entry_mbatch_hash8s(
+        ctx: *mut futhark_context,
+        out0: *mut *mut futhark_u64_2d,
+        out1: *mut *mut futhark_opaque_s8_state,
+        in0: *const futhark_opaque_s8_state,
+        in1: *const futhark_u64_1d,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn futhark_entry_mbatch_hash2s(
+        ctx: *mut futhark_context,
+        out0: *mut *mut futhark_u64_2d,
+        out1: *mut *mut futhark_opaque_s2_state,
+        in0: *const futhark_opaque_s2_state,
         in1: *const futhark_u64_1d,
     ) -> ::std::os::raw::c_int;
 }
@@ -16499,6 +16559,39 @@ extern "C" {
     pub fn futhark_entry_init_t8_64m(
         ctx: *mut futhark_context,
         out0: *mut *mut futhark_opaque_t8_64m_state,
+        in0: *const futhark_u64_1d,
+        in1: *const futhark_u64_2d,
+        in2: *const futhark_u64_3d,
+        in3: *const futhark_u64_3d,
+        in4: *const futhark_u64_3d,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn futhark_entry_init11s(
+        ctx: *mut futhark_context,
+        out0: *mut *mut futhark_opaque_s11_state,
+        in0: *const futhark_u64_1d,
+        in1: *const futhark_u64_2d,
+        in2: *const futhark_u64_3d,
+        in3: *const futhark_u64_3d,
+        in4: *const futhark_u64_3d,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn futhark_entry_init8s(
+        ctx: *mut futhark_context,
+        out0: *mut *mut futhark_opaque_s8_state,
+        in0: *const futhark_u64_1d,
+        in1: *const futhark_u64_2d,
+        in2: *const futhark_u64_3d,
+        in3: *const futhark_u64_3d,
+        in4: *const futhark_u64_3d,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn futhark_entry_init2s(
+        ctx: *mut futhark_context,
+        out0: *mut *mut futhark_opaque_s2_state,
         in0: *const futhark_u64_1d,
         in1: *const futhark_u64_2d,
         in2: *const futhark_u64_3d,

--- a/library/neptune-triton/src/context.rs
+++ b/library/neptune-triton/src/context.rs
@@ -3,7 +3,7 @@ use crate::bindings;
 #[derive(Clone, Copy)]
 pub struct FutharkContext {
     pub context: *mut bindings::futhark_context,
-    config: *mut bindings::futhark_context_config,
+    pub config: *mut bindings::futhark_context_config,
 }
 
 // Safe to implement because Futhark has internal synchronization.
@@ -32,3 +32,4 @@ impl From<FutharkContext> for *mut bindings::futhark_context {
         ctx.ptr()
     }
 }
+

--- a/library/neptune-triton/src/lib.rs
+++ b/library/neptune-triton/src/lib.rs
@@ -61,283 +61,260 @@ impl Display for FutharkError {
 }
 
 impl FutharkContext {
-    pub fn simple8(&mut self, in0: i32) -> Result<(Array_u64_2d)> {
-        let ctx = self.ptr();
-        unsafe { _simple8(ctx, in0) }
-    }
+pub fn simple8(&mut self, in0: i32, ) -> Result<(Array_u64_2d)>
+{
+let ctx = self.ptr();
+unsafe{
+_simple8(ctx, in0, )
+}}
 
-    pub fn build_tree8_64m(
-        &mut self,
-        in0: &FutharkOpaqueT864MState,
-        in1: Array_u64_1d,
-    ) -> Result<(Array_u64_2d)> {
-        let ctx = self.ptr();
-        unsafe { _build_tree8_64m(ctx, in0.as_raw_mut(), in1.as_raw_mut()) }
-    }
+pub fn build_tree8_64m(&mut self, in0: &FutharkOpaqueT864MState, in1: Array_u64_1d, ) -> Result<(Array_u64_2d)>
+{
+let ctx = self.ptr();
+unsafe{
+_build_tree8_64m(ctx, in0.as_raw_mut(), in1.as_raw_mut(), )
+}}
 
-    pub fn mbatch_hash11(
-        &mut self,
-        in0: &FutharkOpaqueP11State,
-        in1: Array_u64_1d,
-    ) -> Result<(Array_u64_2d, FutharkOpaqueP11State)> {
-        let ctx = self.ptr();
-        unsafe { _mbatch_hash11(ctx, in0.as_raw_mut(), in1.as_raw_mut()) }
-    }
+pub fn mbatch_hash11s(&mut self, in0: &FutharkOpaqueS11State, in1: Array_u64_1d, ) -> Result<(Array_u64_2d, FutharkOpaqueS11State)>
+{
+let ctx = self.ptr();
+unsafe{
+_mbatch_hash11s(ctx, in0.as_raw_mut(), in1.as_raw_mut(), )
+}}
 
-    pub fn mbatch_hash8(
-        &mut self,
-        in0: &FutharkOpaqueP8State,
-        in1: Array_u64_1d,
-    ) -> Result<(Array_u64_2d, FutharkOpaqueP8State)> {
-        let ctx = self.ptr();
-        unsafe { _mbatch_hash8(ctx, in0.as_raw_mut(), in1.as_raw_mut()) }
-    }
+pub fn mbatch_hash8s(&mut self, in0: &FutharkOpaqueS8State, in1: Array_u64_1d, ) -> Result<(Array_u64_2d, FutharkOpaqueS8State)>
+{
+let ctx = self.ptr();
+unsafe{
+_mbatch_hash8s(ctx, in0.as_raw_mut(), in1.as_raw_mut(), )
+}}
 
-    pub fn mbatch_hash2(
-        &mut self,
-        in0: &FutharkOpaqueP2State,
-        in1: Array_u64_1d,
-    ) -> Result<(Array_u64_2d, FutharkOpaqueP2State)> {
-        let ctx = self.ptr();
-        unsafe { _mbatch_hash2(ctx, in0.as_raw_mut(), in1.as_raw_mut()) }
-    }
+pub fn mbatch_hash2s(&mut self, in0: &FutharkOpaqueS2State, in1: Array_u64_1d, ) -> Result<(Array_u64_2d, FutharkOpaqueS2State)>
+{
+let ctx = self.ptr();
+unsafe{
+_mbatch_hash2s(ctx, in0.as_raw_mut(), in1.as_raw_mut(), )
+}}
 
-    pub fn hash8(
-        &mut self,
-        in0: &FutharkOpaqueP8State,
-        in1: Array_u64_1d,
-    ) -> Result<(Array_u64_1d, FutharkOpaqueP8State)> {
-        let ctx = self.ptr();
-        unsafe { _hash8(ctx, in0.as_raw_mut(), in1.as_raw_mut()) }
-    }
+pub fn mbatch_hash11(&mut self, in0: &FutharkOpaqueP11State, in1: Array_u64_1d, ) -> Result<(Array_u64_2d, FutharkOpaqueP11State)>
+{
+let ctx = self.ptr();
+unsafe{
+_mbatch_hash11(ctx, in0.as_raw_mut(), in1.as_raw_mut(), )
+}}
 
-    pub fn init_t8_64m(
-        &mut self,
-        in0: Array_u64_1d,
-        in1: Array_u64_2d,
-        in2: Array_u64_3d,
-        in3: Array_u64_3d,
-        in4: Array_u64_3d,
-    ) -> Result<(FutharkOpaqueT864MState)> {
-        let ctx = self.ptr();
-        unsafe {
-            _init_t8_64m(
-                ctx,
-                in0.as_raw_mut(),
-                in1.as_raw_mut(),
-                in2.as_raw_mut(),
-                in3.as_raw_mut(),
-                in4.as_raw_mut(),
-            )
-        }
-    }
+pub fn mbatch_hash8(&mut self, in0: &FutharkOpaqueP8State, in1: Array_u64_1d, ) -> Result<(Array_u64_2d, FutharkOpaqueP8State)>
+{
+let ctx = self.ptr();
+unsafe{
+_mbatch_hash8(ctx, in0.as_raw_mut(), in1.as_raw_mut(), )
+}}
 
-    pub fn init11(
-        &mut self,
-        in0: Array_u64_1d,
-        in1: Array_u64_2d,
-        in2: Array_u64_3d,
-        in3: Array_u64_3d,
-        in4: Array_u64_3d,
-    ) -> Result<(FutharkOpaqueP11State)> {
-        let ctx = self.ptr();
-        unsafe {
-            _init11(
-                ctx,
-                in0.as_raw_mut(),
-                in1.as_raw_mut(),
-                in2.as_raw_mut(),
-                in3.as_raw_mut(),
-                in4.as_raw_mut(),
-            )
-        }
-    }
+pub fn mbatch_hash2(&mut self, in0: &FutharkOpaqueP2State, in1: Array_u64_1d, ) -> Result<(Array_u64_2d, FutharkOpaqueP2State)>
+{
+let ctx = self.ptr();
+unsafe{
+_mbatch_hash2(ctx, in0.as_raw_mut(), in1.as_raw_mut(), )
+}}
 
-    pub fn init8(
-        &mut self,
-        in0: Array_u64_1d,
-        in1: Array_u64_2d,
-        in2: Array_u64_3d,
-        in3: Array_u64_3d,
-        in4: Array_u64_3d,
-    ) -> Result<(FutharkOpaqueP8State)> {
-        let ctx = self.ptr();
-        unsafe {
-            _init8(
-                ctx,
-                in0.as_raw_mut(),
-                in1.as_raw_mut(),
-                in2.as_raw_mut(),
-                in3.as_raw_mut(),
-                in4.as_raw_mut(),
-            )
-        }
-    }
+pub fn hash8(&mut self, in0: &FutharkOpaqueP8State, in1: Array_u64_1d, ) -> Result<(Array_u64_1d, FutharkOpaqueP8State)>
+{
+let ctx = self.ptr();
+unsafe{
+_hash8(ctx, in0.as_raw_mut(), in1.as_raw_mut(), )
+}}
 
-    pub fn init2(
-        &mut self,
-        in0: Array_u64_1d,
-        in1: Array_u64_2d,
-        in2: Array_u64_3d,
-        in3: Array_u64_3d,
-        in4: Array_u64_3d,
-    ) -> Result<(FutharkOpaqueP2State)> {
-        let ctx = self.ptr();
-        unsafe {
-            _init2(
-                ctx,
-                in0.as_raw_mut(),
-                in1.as_raw_mut(),
-                in2.as_raw_mut(),
-                in3.as_raw_mut(),
-                in4.as_raw_mut(),
-            )
-        }
-    }
+pub fn init_t8_64m(&mut self, in0: Array_u64_1d, in1: Array_u64_2d, in2: Array_u64_3d, in3: Array_u64_3d, in4: Array_u64_3d, ) -> Result<(FutharkOpaqueT864MState)>
+{
+let ctx = self.ptr();
+unsafe{
+_init_t8_64m(ctx, in0.as_raw_mut(), in1.as_raw_mut(), in2.as_raw_mut(), in3.as_raw_mut(), in4.as_raw_mut(), )
+}}
+
+pub fn init11s(&mut self, in0: Array_u64_1d, in1: Array_u64_2d, in2: Array_u64_3d, in3: Array_u64_3d, in4: Array_u64_3d, ) -> Result<(FutharkOpaqueS11State)>
+{
+let ctx = self.ptr();
+unsafe{
+_init11s(ctx, in0.as_raw_mut(), in1.as_raw_mut(), in2.as_raw_mut(), in3.as_raw_mut(), in4.as_raw_mut(), )
+}}
+
+pub fn init8s(&mut self, in0: Array_u64_1d, in1: Array_u64_2d, in2: Array_u64_3d, in3: Array_u64_3d, in4: Array_u64_3d, ) -> Result<(FutharkOpaqueS8State)>
+{
+let ctx = self.ptr();
+unsafe{
+_init8s(ctx, in0.as_raw_mut(), in1.as_raw_mut(), in2.as_raw_mut(), in3.as_raw_mut(), in4.as_raw_mut(), )
+}}
+
+pub fn init2s(&mut self, in0: Array_u64_1d, in1: Array_u64_2d, in2: Array_u64_3d, in3: Array_u64_3d, in4: Array_u64_3d, ) -> Result<(FutharkOpaqueS2State)>
+{
+let ctx = self.ptr();
+unsafe{
+_init2s(ctx, in0.as_raw_mut(), in1.as_raw_mut(), in2.as_raw_mut(), in3.as_raw_mut(), in4.as_raw_mut(), )
+}}
+
+pub fn init11(&mut self, in0: Array_u64_1d, in1: Array_u64_2d, in2: Array_u64_3d, in3: Array_u64_3d, in4: Array_u64_3d, ) -> Result<(FutharkOpaqueP11State)>
+{
+let ctx = self.ptr();
+unsafe{
+_init11(ctx, in0.as_raw_mut(), in1.as_raw_mut(), in2.as_raw_mut(), in3.as_raw_mut(), in4.as_raw_mut(), )
+}}
+
+pub fn init8(&mut self, in0: Array_u64_1d, in1: Array_u64_2d, in2: Array_u64_3d, in3: Array_u64_3d, in4: Array_u64_3d, ) -> Result<(FutharkOpaqueP8State)>
+{
+let ctx = self.ptr();
+unsafe{
+_init8(ctx, in0.as_raw_mut(), in1.as_raw_mut(), in2.as_raw_mut(), in3.as_raw_mut(), in4.as_raw_mut(), )
+}}
+
+pub fn init2(&mut self, in0: Array_u64_1d, in1: Array_u64_2d, in2: Array_u64_3d, in3: Array_u64_3d, in4: Array_u64_3d, ) -> Result<(FutharkOpaqueP2State)>
+{
+let ctx = self.ptr();
+unsafe{
+_init2(ctx, in0.as_raw_mut(), in1.as_raw_mut(), in2.as_raw_mut(), in3.as_raw_mut(), in4.as_raw_mut(), )
+}}
+
 }
-unsafe fn _simple8(ctx: *mut bindings::futhark_context, in0: i32) -> Result<(Array_u64_2d)> {
-    let mut raw_out0 = std::ptr::null_mut();
+unsafe fn _simple8(ctx: *mut bindings::futhark_context, in0: i32, ) -> Result<(Array_u64_2d)> {
+let mut raw_out0 = std::ptr::null_mut();
 
-    if bindings::futhark_entry_simple8(ctx, &mut raw_out0, in0) != 0 {
-        return Err(FutharkError::new(ctx).into());
-    }
-    Ok((Array_u64_2d::from_ptr(ctx, raw_out0)))
+if bindings::futhark_entry_simple8(ctx, &mut raw_out0, in0, ) != 0 {
+return Err(FutharkError::new(ctx).into());}
+Ok((Array_u64_2d::from_ptr(ctx, raw_out0)
+))
 }
-unsafe fn _build_tree8_64m(
-    ctx: *mut bindings::futhark_context,
-    in0: *const bindings::futhark_opaque_t8_64m_state,
-    in1: *const bindings::futhark_u64_1d,
-) -> Result<(Array_u64_2d)> {
-    let mut raw_out0 = std::ptr::null_mut();
+unsafe fn _build_tree8_64m(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_opaque_t8_64m_state, in1: *const bindings::futhark_u64_1d, ) -> Result<(Array_u64_2d)> {
+let mut raw_out0 = std::ptr::null_mut();
 
-    if bindings::futhark_entry_build_tree8_64m(ctx, &mut raw_out0, in0, in1) != 0 {
-        return Err(FutharkError::new(ctx).into());
-    }
-    Ok((Array_u64_2d::from_ptr(ctx, raw_out0)))
+if bindings::futhark_entry_build_tree8_64m(ctx, &mut raw_out0, in0, in1, ) != 0 {
+return Err(FutharkError::new(ctx).into());}
+Ok((Array_u64_2d::from_ptr(ctx, raw_out0)
+))
 }
-unsafe fn _mbatch_hash11(
-    ctx: *mut bindings::futhark_context,
-    in0: *const bindings::futhark_opaque_p11_state,
-    in1: *const bindings::futhark_u64_1d,
-) -> Result<(Array_u64_2d, FutharkOpaqueP11State)> {
-    let mut raw_out0 = std::ptr::null_mut();
-    let mut raw_out1 = std::ptr::null_mut();
+unsafe fn _mbatch_hash11s(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_opaque_s11_state, in1: *const bindings::futhark_u64_1d, ) -> Result<(Array_u64_2d, FutharkOpaqueS11State)> {
+let mut raw_out0 = std::ptr::null_mut();
+let mut raw_out1 = std::ptr::null_mut();
 
-    if bindings::futhark_entry_mbatch_hash11(ctx, &mut raw_out0, &mut raw_out1, in0, in1) != 0 {
-        return Err(FutharkError::new(ctx).into());
-    }
-    Ok((
-        Array_u64_2d::from_ptr(ctx, raw_out0),
-        FutharkOpaqueP11State::from_ptr(ctx, raw_out1),
-    ))
+if bindings::futhark_entry_mbatch_hash11s(ctx, &mut raw_out0, &mut raw_out1, in0, in1, ) != 0 {
+return Err(FutharkError::new(ctx).into());}
+Ok((Array_u64_2d::from_ptr(ctx, raw_out0)
+, FutharkOpaqueS11State::from_ptr(ctx, raw_out1)
+))
 }
-unsafe fn _mbatch_hash8(
-    ctx: *mut bindings::futhark_context,
-    in0: *const bindings::futhark_opaque_p8_state,
-    in1: *const bindings::futhark_u64_1d,
-) -> Result<(Array_u64_2d, FutharkOpaqueP8State)> {
-    let mut raw_out0 = std::ptr::null_mut();
-    let mut raw_out1 = std::ptr::null_mut();
+unsafe fn _mbatch_hash8s(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_opaque_s8_state, in1: *const bindings::futhark_u64_1d, ) -> Result<(Array_u64_2d, FutharkOpaqueS8State)> {
+let mut raw_out0 = std::ptr::null_mut();
+let mut raw_out1 = std::ptr::null_mut();
 
-    if bindings::futhark_entry_mbatch_hash8(ctx, &mut raw_out0, &mut raw_out1, in0, in1) != 0 {
-        return Err(FutharkError::new(ctx).into());
-    }
-    Ok((
-        Array_u64_2d::from_ptr(ctx, raw_out0),
-        FutharkOpaqueP8State::from_ptr(ctx, raw_out1),
-    ))
+if bindings::futhark_entry_mbatch_hash8s(ctx, &mut raw_out0, &mut raw_out1, in0, in1, ) != 0 {
+return Err(FutharkError::new(ctx).into());}
+Ok((Array_u64_2d::from_ptr(ctx, raw_out0)
+, FutharkOpaqueS8State::from_ptr(ctx, raw_out1)
+))
 }
-unsafe fn _mbatch_hash2(
-    ctx: *mut bindings::futhark_context,
-    in0: *const bindings::futhark_opaque_p2_state,
-    in1: *const bindings::futhark_u64_1d,
-) -> Result<(Array_u64_2d, FutharkOpaqueP2State)> {
-    let mut raw_out0 = std::ptr::null_mut();
-    let mut raw_out1 = std::ptr::null_mut();
+unsafe fn _mbatch_hash2s(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_opaque_s2_state, in1: *const bindings::futhark_u64_1d, ) -> Result<(Array_u64_2d, FutharkOpaqueS2State)> {
+let mut raw_out0 = std::ptr::null_mut();
+let mut raw_out1 = std::ptr::null_mut();
 
-    if bindings::futhark_entry_mbatch_hash2(ctx, &mut raw_out0, &mut raw_out1, in0, in1) != 0 {
-        return Err(FutharkError::new(ctx).into());
-    }
-    Ok((
-        Array_u64_2d::from_ptr(ctx, raw_out0),
-        FutharkOpaqueP2State::from_ptr(ctx, raw_out1),
-    ))
+if bindings::futhark_entry_mbatch_hash2s(ctx, &mut raw_out0, &mut raw_out1, in0, in1, ) != 0 {
+return Err(FutharkError::new(ctx).into());}
+Ok((Array_u64_2d::from_ptr(ctx, raw_out0)
+, FutharkOpaqueS2State::from_ptr(ctx, raw_out1)
+))
 }
-unsafe fn _hash8(
-    ctx: *mut bindings::futhark_context,
-    in0: *const bindings::futhark_opaque_p8_state,
-    in1: *const bindings::futhark_u64_1d,
-) -> Result<(Array_u64_1d, FutharkOpaqueP8State)> {
-    let mut raw_out0 = std::ptr::null_mut();
-    let mut raw_out1 = std::ptr::null_mut();
+unsafe fn _mbatch_hash11(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_opaque_p11_state, in1: *const bindings::futhark_u64_1d, ) -> Result<(Array_u64_2d, FutharkOpaqueP11State)> {
+let mut raw_out0 = std::ptr::null_mut();
+let mut raw_out1 = std::ptr::null_mut();
 
-    if bindings::futhark_entry_hash8(ctx, &mut raw_out0, &mut raw_out1, in0, in1) != 0 {
-        return Err(FutharkError::new(ctx).into());
-    }
-    Ok((
-        Array_u64_1d::from_ptr(ctx, raw_out0),
-        FutharkOpaqueP8State::from_ptr(ctx, raw_out1),
-    ))
+if bindings::futhark_entry_mbatch_hash11(ctx, &mut raw_out0, &mut raw_out1, in0, in1, ) != 0 {
+return Err(FutharkError::new(ctx).into());}
+Ok((Array_u64_2d::from_ptr(ctx, raw_out0)
+, FutharkOpaqueP11State::from_ptr(ctx, raw_out1)
+))
 }
-unsafe fn _init_t8_64m(
-    ctx: *mut bindings::futhark_context,
-    in0: *const bindings::futhark_u64_1d,
-    in1: *const bindings::futhark_u64_2d,
-    in2: *const bindings::futhark_u64_3d,
-    in3: *const bindings::futhark_u64_3d,
-    in4: *const bindings::futhark_u64_3d,
-) -> Result<(FutharkOpaqueT864MState)> {
-    let mut raw_out0 = std::ptr::null_mut();
+unsafe fn _mbatch_hash8(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_opaque_p8_state, in1: *const bindings::futhark_u64_1d, ) -> Result<(Array_u64_2d, FutharkOpaqueP8State)> {
+let mut raw_out0 = std::ptr::null_mut();
+let mut raw_out1 = std::ptr::null_mut();
 
-    if bindings::futhark_entry_init_t8_64m(ctx, &mut raw_out0, in0, in1, in2, in3, in4) != 0 {
-        return Err(FutharkError::new(ctx).into());
-    }
-    Ok((FutharkOpaqueT864MState::from_ptr(ctx, raw_out0)))
+if bindings::futhark_entry_mbatch_hash8(ctx, &mut raw_out0, &mut raw_out1, in0, in1, ) != 0 {
+return Err(FutharkError::new(ctx).into());}
+Ok((Array_u64_2d::from_ptr(ctx, raw_out0)
+, FutharkOpaqueP8State::from_ptr(ctx, raw_out1)
+))
 }
-unsafe fn _init11(
-    ctx: *mut bindings::futhark_context,
-    in0: *const bindings::futhark_u64_1d,
-    in1: *const bindings::futhark_u64_2d,
-    in2: *const bindings::futhark_u64_3d,
-    in3: *const bindings::futhark_u64_3d,
-    in4: *const bindings::futhark_u64_3d,
-) -> Result<(FutharkOpaqueP11State)> {
-    let mut raw_out0 = std::ptr::null_mut();
+unsafe fn _mbatch_hash2(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_opaque_p2_state, in1: *const bindings::futhark_u64_1d, ) -> Result<(Array_u64_2d, FutharkOpaqueP2State)> {
+let mut raw_out0 = std::ptr::null_mut();
+let mut raw_out1 = std::ptr::null_mut();
 
-    if bindings::futhark_entry_init11(ctx, &mut raw_out0, in0, in1, in2, in3, in4) != 0 {
-        return Err(FutharkError::new(ctx).into());
-    }
-    Ok((FutharkOpaqueP11State::from_ptr(ctx, raw_out0)))
+if bindings::futhark_entry_mbatch_hash2(ctx, &mut raw_out0, &mut raw_out1, in0, in1, ) != 0 {
+return Err(FutharkError::new(ctx).into());}
+Ok((Array_u64_2d::from_ptr(ctx, raw_out0)
+, FutharkOpaqueP2State::from_ptr(ctx, raw_out1)
+))
 }
-unsafe fn _init8(
-    ctx: *mut bindings::futhark_context,
-    in0: *const bindings::futhark_u64_1d,
-    in1: *const bindings::futhark_u64_2d,
-    in2: *const bindings::futhark_u64_3d,
-    in3: *const bindings::futhark_u64_3d,
-    in4: *const bindings::futhark_u64_3d,
-) -> Result<(FutharkOpaqueP8State)> {
-    let mut raw_out0 = std::ptr::null_mut();
+unsafe fn _hash8(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_opaque_p8_state, in1: *const bindings::futhark_u64_1d, ) -> Result<(Array_u64_1d, FutharkOpaqueP8State)> {
+let mut raw_out0 = std::ptr::null_mut();
+let mut raw_out1 = std::ptr::null_mut();
 
-    if bindings::futhark_entry_init8(ctx, &mut raw_out0, in0, in1, in2, in3, in4) != 0 {
-        return Err(FutharkError::new(ctx).into());
-    }
-    Ok((FutharkOpaqueP8State::from_ptr(ctx, raw_out0)))
+if bindings::futhark_entry_hash8(ctx, &mut raw_out0, &mut raw_out1, in0, in1, ) != 0 {
+return Err(FutharkError::new(ctx).into());}
+Ok((Array_u64_1d::from_ptr(ctx, raw_out0)
+, FutharkOpaqueP8State::from_ptr(ctx, raw_out1)
+))
 }
-unsafe fn _init2(
-    ctx: *mut bindings::futhark_context,
-    in0: *const bindings::futhark_u64_1d,
-    in1: *const bindings::futhark_u64_2d,
-    in2: *const bindings::futhark_u64_3d,
-    in3: *const bindings::futhark_u64_3d,
-    in4: *const bindings::futhark_u64_3d,
-) -> Result<(FutharkOpaqueP2State)> {
-    let mut raw_out0 = std::ptr::null_mut();
+unsafe fn _init_t8_64m(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_u64_1d, in1: *const bindings::futhark_u64_2d, in2: *const bindings::futhark_u64_3d, in3: *const bindings::futhark_u64_3d, in4: *const bindings::futhark_u64_3d, ) -> Result<(FutharkOpaqueT864MState)> {
+let mut raw_out0 = std::ptr::null_mut();
 
-    if bindings::futhark_entry_init2(ctx, &mut raw_out0, in0, in1, in2, in3, in4) != 0 {
-        return Err(FutharkError::new(ctx).into());
-    }
-    Ok((FutharkOpaqueP2State::from_ptr(ctx, raw_out0)))
+if bindings::futhark_entry_init_t8_64m(ctx, &mut raw_out0, in0, in1, in2, in3, in4, ) != 0 {
+return Err(FutharkError::new(ctx).into());}
+Ok((FutharkOpaqueT864MState::from_ptr(ctx, raw_out0)
+))
+}
+unsafe fn _init11s(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_u64_1d, in1: *const bindings::futhark_u64_2d, in2: *const bindings::futhark_u64_3d, in3: *const bindings::futhark_u64_3d, in4: *const bindings::futhark_u64_3d, ) -> Result<(FutharkOpaqueS11State)> {
+let mut raw_out0 = std::ptr::null_mut();
+
+if bindings::futhark_entry_init11s(ctx, &mut raw_out0, in0, in1, in2, in3, in4, ) != 0 {
+return Err(FutharkError::new(ctx).into());}
+Ok((FutharkOpaqueS11State::from_ptr(ctx, raw_out0)
+))
+}
+unsafe fn _init8s(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_u64_1d, in1: *const bindings::futhark_u64_2d, in2: *const bindings::futhark_u64_3d, in3: *const bindings::futhark_u64_3d, in4: *const bindings::futhark_u64_3d, ) -> Result<(FutharkOpaqueS8State)> {
+let mut raw_out0 = std::ptr::null_mut();
+
+if bindings::futhark_entry_init8s(ctx, &mut raw_out0, in0, in1, in2, in3, in4, ) != 0 {
+return Err(FutharkError::new(ctx).into());}
+Ok((FutharkOpaqueS8State::from_ptr(ctx, raw_out0)
+))
+}
+unsafe fn _init2s(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_u64_1d, in1: *const bindings::futhark_u64_2d, in2: *const bindings::futhark_u64_3d, in3: *const bindings::futhark_u64_3d, in4: *const bindings::futhark_u64_3d, ) -> Result<(FutharkOpaqueS2State)> {
+let mut raw_out0 = std::ptr::null_mut();
+
+if bindings::futhark_entry_init2s(ctx, &mut raw_out0, in0, in1, in2, in3, in4, ) != 0 {
+return Err(FutharkError::new(ctx).into());}
+Ok((FutharkOpaqueS2State::from_ptr(ctx, raw_out0)
+))
+}
+unsafe fn _init11(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_u64_1d, in1: *const bindings::futhark_u64_2d, in2: *const bindings::futhark_u64_3d, in3: *const bindings::futhark_u64_3d, in4: *const bindings::futhark_u64_3d, ) -> Result<(FutharkOpaqueP11State)> {
+let mut raw_out0 = std::ptr::null_mut();
+
+if bindings::futhark_entry_init11(ctx, &mut raw_out0, in0, in1, in2, in3, in4, ) != 0 {
+return Err(FutharkError::new(ctx).into());}
+Ok((FutharkOpaqueP11State::from_ptr(ctx, raw_out0)
+))
+}
+unsafe fn _init8(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_u64_1d, in1: *const bindings::futhark_u64_2d, in2: *const bindings::futhark_u64_3d, in3: *const bindings::futhark_u64_3d, in4: *const bindings::futhark_u64_3d, ) -> Result<(FutharkOpaqueP8State)> {
+let mut raw_out0 = std::ptr::null_mut();
+
+if bindings::futhark_entry_init8(ctx, &mut raw_out0, in0, in1, in2, in3, in4, ) != 0 {
+return Err(FutharkError::new(ctx).into());}
+Ok((FutharkOpaqueP8State::from_ptr(ctx, raw_out0)
+))
+}
+unsafe fn _init2(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_u64_1d, in1: *const bindings::futhark_u64_2d, in2: *const bindings::futhark_u64_3d, in3: *const bindings::futhark_u64_3d, in4: *const bindings::futhark_u64_3d, ) -> Result<(FutharkOpaqueP2State)> {
+let mut raw_out0 = std::ptr::null_mut();
+
+if bindings::futhark_entry_init2(ctx, &mut raw_out0, in0, in1, in2, in3, in4, ) != 0 {
+return Err(FutharkError::new(ctx).into());}
+Ok((FutharkOpaqueP2State::from_ptr(ctx, raw_out0)
+))
 }
 #[derive(Debug)]
 pub struct FutharkOpaqueP11State {
@@ -347,21 +324,22 @@ pub struct FutharkOpaqueP11State {
 
 impl FutharkOpaqueP11State {
     pub(crate) unsafe fn as_raw(&self) -> *const bindings::futhark_opaque_p11_state {
-        self.ptr
+         self.ptr
     }
 
     pub(crate) unsafe fn as_raw_mut(&self) -> *mut bindings::futhark_opaque_p11_state {
-        self.ptr as *mut bindings::futhark_opaque_p11_state
+         self.ptr as *mut bindings::futhark_opaque_p11_state
     }
     pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const bindings::futhark_opaque_p11_state) -> Self
-    where
+        where
         T: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         Self { ptr, ctx }
     }
 
-    pub(crate) unsafe fn free_opaque(&mut self) {
+    pub(crate) unsafe fn free_opaque(&mut self)
+    {
         bindings::futhark_free_opaque_p11_state(self.ctx, self.as_raw_mut());
     }
 }
@@ -382,21 +360,22 @@ pub struct FutharkOpaqueP2State {
 
 impl FutharkOpaqueP2State {
     pub(crate) unsafe fn as_raw(&self) -> *const bindings::futhark_opaque_p2_state {
-        self.ptr
+         self.ptr
     }
 
     pub(crate) unsafe fn as_raw_mut(&self) -> *mut bindings::futhark_opaque_p2_state {
-        self.ptr as *mut bindings::futhark_opaque_p2_state
+         self.ptr as *mut bindings::futhark_opaque_p2_state
     }
     pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const bindings::futhark_opaque_p2_state) -> Self
-    where
+        where
         T: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         Self { ptr, ctx }
     }
 
-    pub(crate) unsafe fn free_opaque(&mut self) {
+    pub(crate) unsafe fn free_opaque(&mut self)
+    {
         bindings::futhark_free_opaque_p2_state(self.ctx, self.as_raw_mut());
     }
 }
@@ -417,26 +396,135 @@ pub struct FutharkOpaqueP8State {
 
 impl FutharkOpaqueP8State {
     pub(crate) unsafe fn as_raw(&self) -> *const bindings::futhark_opaque_p8_state {
-        self.ptr
+         self.ptr
     }
 
     pub(crate) unsafe fn as_raw_mut(&self) -> *mut bindings::futhark_opaque_p8_state {
-        self.ptr as *mut bindings::futhark_opaque_p8_state
+         self.ptr as *mut bindings::futhark_opaque_p8_state
     }
     pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const bindings::futhark_opaque_p8_state) -> Self
-    where
+        where
         T: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         Self { ptr, ctx }
     }
 
-    pub(crate) unsafe fn free_opaque(&mut self) {
+    pub(crate) unsafe fn free_opaque(&mut self)
+    {
         bindings::futhark_free_opaque_p8_state(self.ctx, self.as_raw_mut());
     }
 }
 
 impl Drop for FutharkOpaqueP8State {
+    fn drop(&mut self) {
+        unsafe {
+            self.free_opaque();
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct FutharkOpaqueS11State {
+    ptr: *const bindings::futhark_opaque_s11_state,
+    ctx: *mut bindings::futhark_context,
+}
+
+impl FutharkOpaqueS11State {
+    pub(crate) unsafe fn as_raw(&self) -> *const bindings::futhark_opaque_s11_state {
+         self.ptr
+    }
+
+    pub(crate) unsafe fn as_raw_mut(&self) -> *mut bindings::futhark_opaque_s11_state {
+         self.ptr as *mut bindings::futhark_opaque_s11_state
+    }
+    pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const bindings::futhark_opaque_s11_state) -> Self
+        where
+        T: Into<*mut bindings::futhark_context>,
+    {
+        let ctx = ctx.into();
+        Self { ptr, ctx }
+    }
+
+    pub(crate) unsafe fn free_opaque(&mut self)
+    {
+        bindings::futhark_free_opaque_s11_state(self.ctx, self.as_raw_mut());
+    }
+}
+
+impl Drop for FutharkOpaqueS11State {
+    fn drop(&mut self) {
+        unsafe {
+            self.free_opaque();
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct FutharkOpaqueS2State {
+    ptr: *const bindings::futhark_opaque_s2_state,
+    ctx: *mut bindings::futhark_context,
+}
+
+impl FutharkOpaqueS2State {
+    pub(crate) unsafe fn as_raw(&self) -> *const bindings::futhark_opaque_s2_state {
+         self.ptr
+    }
+
+    pub(crate) unsafe fn as_raw_mut(&self) -> *mut bindings::futhark_opaque_s2_state {
+         self.ptr as *mut bindings::futhark_opaque_s2_state
+    }
+    pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const bindings::futhark_opaque_s2_state) -> Self
+        where
+        T: Into<*mut bindings::futhark_context>,
+    {
+        let ctx = ctx.into();
+        Self { ptr, ctx }
+    }
+
+    pub(crate) unsafe fn free_opaque(&mut self)
+    {
+        bindings::futhark_free_opaque_s2_state(self.ctx, self.as_raw_mut());
+    }
+}
+
+impl Drop for FutharkOpaqueS2State {
+    fn drop(&mut self) {
+        unsafe {
+            self.free_opaque();
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct FutharkOpaqueS8State {
+    ptr: *const bindings::futhark_opaque_s8_state,
+    ctx: *mut bindings::futhark_context,
+}
+
+impl FutharkOpaqueS8State {
+    pub(crate) unsafe fn as_raw(&self) -> *const bindings::futhark_opaque_s8_state {
+         self.ptr
+    }
+
+    pub(crate) unsafe fn as_raw_mut(&self) -> *mut bindings::futhark_opaque_s8_state {
+         self.ptr as *mut bindings::futhark_opaque_s8_state
+    }
+    pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const bindings::futhark_opaque_s8_state) -> Self
+        where
+        T: Into<*mut bindings::futhark_context>,
+    {
+        let ctx = ctx.into();
+        Self { ptr, ctx }
+    }
+
+    pub(crate) unsafe fn free_opaque(&mut self)
+    {
+        bindings::futhark_free_opaque_s8_state(self.ctx, self.as_raw_mut());
+    }
+}
+
+impl Drop for FutharkOpaqueS8State {
     fn drop(&mut self) {
         unsafe {
             self.free_opaque();
@@ -452,24 +540,22 @@ pub struct FutharkOpaqueT864MState {
 
 impl FutharkOpaqueT864MState {
     pub(crate) unsafe fn as_raw(&self) -> *const bindings::futhark_opaque_t8_64m_state {
-        self.ptr
+         self.ptr
     }
 
     pub(crate) unsafe fn as_raw_mut(&self) -> *mut bindings::futhark_opaque_t8_64m_state {
-        self.ptr as *mut bindings::futhark_opaque_t8_64m_state
+         self.ptr as *mut bindings::futhark_opaque_t8_64m_state
     }
-    pub(crate) unsafe fn from_ptr<T>(
-        ctx: T,
-        ptr: *const bindings::futhark_opaque_t8_64m_state,
-    ) -> Self
-    where
+    pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const bindings::futhark_opaque_t8_64m_state) -> Self
+        where
         T: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         Self { ptr, ctx }
     }
 
-    pub(crate) unsafe fn free_opaque(&mut self) {
+    pub(crate) unsafe fn free_opaque(&mut self)
+    {
         bindings::futhark_free_opaque_t8_64m_state(self.ctx, self.as_raw_mut());
     }
 }
@@ -481,3 +567,6 @@ impl Drop for FutharkOpaqueT864MState {
         }
     }
 }
+
+
+

--- a/library/neptune-triton/src/traits.rs
+++ b/library/neptune-triton/src/traits.rs
@@ -18,3 +18,4 @@ where
         U::from_ctx(self, ctx)
     }
 }
+

--- a/library/src/bin/codegen.rs
+++ b/library/src/bin/codegen.rs
@@ -3,7 +3,7 @@ fn main() {
         name: "neptune-triton".to_string(),
         file: std::path::PathBuf::from("poseidon.fut"),
         author: "porcuquine@gmail.com".to_string(),
-        version: "0.2.2".to_string(),
+        version: "1.0.0".to_string(),
         description: "GPU implementation of neptune-compatible Poseidon hashing.".to_string(),
         license: "MIT OR Apache-2.0".to_string(),
     })


### PR DESCRIPTION
Add support for strengthened versions of 2, 8, and 11-ary poseidon hashes. Strengthened means 1.25% (rounded up) the number of partial rounds, as calculated canonically in https://github.com/filecoin-project/neptune.

The generated `Cargo.toml` bumps the `neptune-triton` version to 1.0.0. Once this merges, the generated crate will be published.