### PR TITLE
Use genfut 0.3.0.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,9 @@ jobs:
       - *restore-cache
       - run: echo 'export PATH="$HOME:~/.cargo/bin:$PATH"' >> $BASH_ENV
       - run: source $BASH_ENV
+      - run: sudo apt-get update -y
+      - run: apt-cache search opencl
+      - run: sudo apt install -y ocl-icd-opencl-dev
       - run:
           name: Run cargo release build
           command: cargo build --release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,21 +90,6 @@ jobs:
       - run:
           name: Run cargo fmt
           command: cargo fmt --all -- --check
-
-  clippy:
-    executor: default
-    steps:
-      - *restore-workspace
-      - *restore-cache
-      - run: echo 'export PATH="$HOME:~/.cargo/bin:$PATH"' >> $BASH_ENV
-      - run: source $BASH_ENV
-      - run: sudo apt-get update -y
-      - run: apt-cache search opencl
-      - run: sudo apt install -y ocl-icd-opencl-dev
-      - run:
-          name: Run cargo clippy
-          command: cargo clippy --all-features
-
   build:
     executor: default
     steps:
@@ -116,20 +101,6 @@ jobs:
           name: Run cargo release build
           command: cargo build --release
 
-  benches:
-    executor: default
-    steps:
-      - *restore-workspace
-      - *restore-cache
-      - run: echo 'export PATH="$HOME:~/.cargo/bin:$PATH"' >> $BASH_ENV
-      - run: source $BASH_ENV
-      - run: sudo apt-get update -y
-      - run: apt-cache search opencl
-      - run: sudo apt install -y ocl-icd-opencl-dev
-      - run:
-          name: Run cargo build --benches
-          command: cargo build --benches --all-features --all --release
-
 workflows:
   version: 2.1
 
@@ -139,15 +110,9 @@ workflows:
       - rustfmt:
           requires:
             - cargo_fetch
-      - clippy:
-          requires:
-            - cargo_fetch
       - test_x86_64-unknown-linux-gnu:
           requires:
             - cargo_fetch
       - build:
-          requires:
-            - cargo_fetch
-      - benches:
           requires:
             - cargo_fetch

--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/filecoin-project/neptune-triton/tree/master/lib
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-genfut = { version = "0.2.1", default-features = false, features = ["opencl"] }
+genfut = { version = "0.3.0", default-features = false, features = ["opencl"] }
 
 [[bin]]
 name="codegen"

--- a/library/neptune-triton/Cargo.toml
+++ b/library/neptune-triton/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "neptune-triton"
 description = "GPU implementation of neptune-compatible Poseidon hashing."
-version = "1.1.0"
+version = "1.1.1"
 authors = ["porcuquine@gmail.com"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/library/neptune-triton/build.rs
+++ b/library/neptune-triton/build.rs
@@ -6,6 +6,7 @@ fn main() {
     cc::Build::new()
         .file("./lib/a.c")
         .flag("-fPIC")
+        .flag("-std=c99")
         .shared_flag(true)
         .warnings(false)
         .compile("a");
@@ -17,6 +18,7 @@ fn main() {
         .cuda(true)
         .flag("-Xcompiler")
         .flag("-fPIC")
+        .flag("-std=c99")
         .flag("-w")
         .shared_flag(true)
         .compile("a");
@@ -37,20 +39,11 @@ fn main() {
             cc::Build::new()
                 .file("./lib/a.c")
                 .flag("-fPIC")
+                .flag("-std=c99")
                 .flag("-lOpenCL")
                 .shared_flag(true)
                 .compile("a");
             println!("cargo:rustc-link-lib=dylib=OpenCL");
-        }
-        #[cfg(target_os = "macos")]
-        {
-            cc::Build::new()
-                .file("./lib/a.c")
-                .flag("-fPIC")
-                .flag("-framework")
-                .flag("OpenCL")
-                .shared_flag(true)
-                .compile("a");
         }
     }
 }

--- a/library/neptune-triton/lib/a.fut
+++ b/library/neptune-triton/lib/a.fut
@@ -1,4 +1,4 @@
-module F = import "lib/github.com/porcuquine/fut-ff/field"
+module F = import "lib/github.com/filecoin-project/fut-ff/field"
 
 import "lib/github.com/athas/vector/vector"
 module vector_2 = cat_vector vector_1 vector_1

--- a/library/neptune-triton/src/arrays.rs
+++ b/library/neptune-triton/src/arrays.rs
@@ -20,30 +20,29 @@ pub(crate) trait FutharkType {
 use crate::bindings::*;
 
 impl futhark_i64_1d {
-   unsafe fn new<C>(ctx: C, arr: &[i64], dim: &[i64]) -> *const Self
-   where C: Into<*mut bindings::futhark_context>
-   {
-     let ctx = ctx.into();
-     bindings::futhark_new_i64_1d(
-       ctx,
-       arr.as_ptr() as *mut i64,
-       dim[0],
-)
-     }
+    unsafe fn new<C>(ctx: C, arr: &[i64], dim: &[i64]) -> *const Self
+    where
+        C: Into<*mut bindings::futhark_context>,
+    {
+        let ctx = ctx.into();
+        bindings::futhark_new_i64_1d(ctx, arr.as_ptr() as *mut i64, dim[0])
+    }
 }
 
 impl FutharkType for futhark_i64_1d {
-   type RustType = i64;
-   const DIM: usize = 1;
+    type RustType = i64;
+    const DIM: usize = 1;
 
     unsafe fn shape<C>(ctx: C, ptr: *const bindings::futhark_i64_1d) -> *const i64
-    where C: Into<*mut bindings::futhark_context>
+    where
+        C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         bindings::futhark_shape_i64_1d(ctx, ptr as *mut bindings::futhark_i64_1d)
     }
     unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType)
-    where C: Into<*mut bindings::futhark_context>
+    where
+        C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         bindings::futhark_values_i64_1d(ctx, ptr, dst);
@@ -51,38 +50,38 @@ impl FutharkType for futhark_i64_1d {
         bindings::futhark_context_sync(ctx);
     }
     unsafe fn free<C>(ctx: C, ptr: *mut Self)
-    where C: Into<*mut bindings::futhark_context>
+    where
+        C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         bindings::futhark_free_i64_1d(ctx, ptr);
-    }}
+    }
+}
 
 impl futhark_i64_2d {
-   unsafe fn new<C>(ctx: C, arr: &[i64], dim: &[i64]) -> *const Self
-   where C: Into<*mut bindings::futhark_context>
-   {
-     let ctx = ctx.into();
-     bindings::futhark_new_i64_2d(
-       ctx,
-       arr.as_ptr() as *mut i64,
-       dim[0],
-dim[1],
-)
-     }
+    unsafe fn new<C>(ctx: C, arr: &[i64], dim: &[i64]) -> *const Self
+    where
+        C: Into<*mut bindings::futhark_context>,
+    {
+        let ctx = ctx.into();
+        bindings::futhark_new_i64_2d(ctx, arr.as_ptr() as *mut i64, dim[0], dim[1])
+    }
 }
 
 impl FutharkType for futhark_i64_2d {
-   type RustType = i64;
-   const DIM: usize = 2;
+    type RustType = i64;
+    const DIM: usize = 2;
 
     unsafe fn shape<C>(ctx: C, ptr: *const bindings::futhark_i64_2d) -> *const i64
-    where C: Into<*mut bindings::futhark_context>
+    where
+        C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         bindings::futhark_shape_i64_2d(ctx, ptr as *mut bindings::futhark_i64_2d)
     }
     unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType)
-    where C: Into<*mut bindings::futhark_context>
+    where
+        C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         bindings::futhark_values_i64_2d(ctx, ptr, dst);
@@ -90,37 +89,38 @@ impl FutharkType for futhark_i64_2d {
         bindings::futhark_context_sync(ctx);
     }
     unsafe fn free<C>(ctx: C, ptr: *mut Self)
-    where C: Into<*mut bindings::futhark_context>
+    where
+        C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         bindings::futhark_free_i64_2d(ctx, ptr);
-    }}
+    }
+}
 
 impl futhark_u64_1d {
-   unsafe fn new<C>(ctx: C, arr: &[u64], dim: &[i64]) -> *const Self
-   where C: Into<*mut bindings::futhark_context>
-   {
-     let ctx = ctx.into();
-     bindings::futhark_new_u64_1d(
-       ctx,
-       arr.as_ptr() as *mut u64,
-       dim[0],
-)
-     }
+    unsafe fn new<C>(ctx: C, arr: &[u64], dim: &[i64]) -> *const Self
+    where
+        C: Into<*mut bindings::futhark_context>,
+    {
+        let ctx = ctx.into();
+        bindings::futhark_new_u64_1d(ctx, arr.as_ptr() as *mut u64, dim[0])
+    }
 }
 
 impl FutharkType for futhark_u64_1d {
-   type RustType = u64;
-   const DIM: usize = 1;
+    type RustType = u64;
+    const DIM: usize = 1;
 
     unsafe fn shape<C>(ctx: C, ptr: *const bindings::futhark_u64_1d) -> *const i64
-    where C: Into<*mut bindings::futhark_context>
+    where
+        C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         bindings::futhark_shape_u64_1d(ctx, ptr as *mut bindings::futhark_u64_1d)
     }
     unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType)
-    where C: Into<*mut bindings::futhark_context>
+    where
+        C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         bindings::futhark_values_u64_1d(ctx, ptr, dst);
@@ -128,38 +128,38 @@ impl FutharkType for futhark_u64_1d {
         bindings::futhark_context_sync(ctx);
     }
     unsafe fn free<C>(ctx: C, ptr: *mut Self)
-    where C: Into<*mut bindings::futhark_context>
+    where
+        C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         bindings::futhark_free_u64_1d(ctx, ptr);
-    }}
+    }
+}
 
 impl futhark_u64_2d {
-   unsafe fn new<C>(ctx: C, arr: &[u64], dim: &[i64]) -> *const Self
-   where C: Into<*mut bindings::futhark_context>
-   {
-     let ctx = ctx.into();
-     bindings::futhark_new_u64_2d(
-       ctx,
-       arr.as_ptr() as *mut u64,
-       dim[0],
-dim[1],
-)
-     }
+    unsafe fn new<C>(ctx: C, arr: &[u64], dim: &[i64]) -> *const Self
+    where
+        C: Into<*mut bindings::futhark_context>,
+    {
+        let ctx = ctx.into();
+        bindings::futhark_new_u64_2d(ctx, arr.as_ptr() as *mut u64, dim[0], dim[1])
+    }
 }
 
 impl FutharkType for futhark_u64_2d {
-   type RustType = u64;
-   const DIM: usize = 2;
+    type RustType = u64;
+    const DIM: usize = 2;
 
     unsafe fn shape<C>(ctx: C, ptr: *const bindings::futhark_u64_2d) -> *const i64
-    where C: Into<*mut bindings::futhark_context>
+    where
+        C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         bindings::futhark_shape_u64_2d(ctx, ptr as *mut bindings::futhark_u64_2d)
     }
     unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType)
-    where C: Into<*mut bindings::futhark_context>
+    where
+        C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         bindings::futhark_values_u64_2d(ctx, ptr, dst);
@@ -167,39 +167,38 @@ impl FutharkType for futhark_u64_2d {
         bindings::futhark_context_sync(ctx);
     }
     unsafe fn free<C>(ctx: C, ptr: *mut Self)
-    where C: Into<*mut bindings::futhark_context>
+    where
+        C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         bindings::futhark_free_u64_2d(ctx, ptr);
-    }}
+    }
+}
 
 impl futhark_u64_3d {
-   unsafe fn new<C>(ctx: C, arr: &[u64], dim: &[i64]) -> *const Self
-   where C: Into<*mut bindings::futhark_context>
-   {
-     let ctx = ctx.into();
-     bindings::futhark_new_u64_3d(
-       ctx,
-       arr.as_ptr() as *mut u64,
-       dim[0],
-dim[1],
-dim[2],
-)
-     }
+    unsafe fn new<C>(ctx: C, arr: &[u64], dim: &[i64]) -> *const Self
+    where
+        C: Into<*mut bindings::futhark_context>,
+    {
+        let ctx = ctx.into();
+        bindings::futhark_new_u64_3d(ctx, arr.as_ptr() as *mut u64, dim[0], dim[1], dim[2])
+    }
 }
 
 impl FutharkType for futhark_u64_3d {
-   type RustType = u64;
-   const DIM: usize = 3;
+    type RustType = u64;
+    const DIM: usize = 3;
 
     unsafe fn shape<C>(ctx: C, ptr: *const bindings::futhark_u64_3d) -> *const i64
-    where C: Into<*mut bindings::futhark_context>
+    where
+        C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         bindings::futhark_shape_u64_3d(ctx, ptr as *mut bindings::futhark_u64_3d)
     }
     unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType)
-    where C: Into<*mut bindings::futhark_context>
+    where
+        C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         bindings::futhark_values_u64_3d(ctx, ptr, dst);
@@ -207,28 +206,29 @@ impl FutharkType for futhark_u64_3d {
         bindings::futhark_context_sync(ctx);
     }
     unsafe fn free<C>(ctx: C, ptr: *mut Self)
-    where C: Into<*mut bindings::futhark_context>
+    where
+        C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         bindings::futhark_free_u64_3d(ctx, ptr);
-    }}
+    }
+}
 #[derive(Debug)]
 pub struct Array_i64_1d {
     ptr: *const futhark_i64_1d,
     ctx: *mut bindings::futhark_context,
 }
 
-
 impl Array_i64_1d {
     pub(crate) unsafe fn as_raw(&self) -> *const futhark_i64_1d {
-         self.ptr
+        self.ptr
     }
 
     pub(crate) unsafe fn as_raw_mut(&self) -> *mut futhark_i64_1d {
-         self.ptr as *mut futhark_i64_1d
+        self.ptr as *mut futhark_i64_1d
     }
     pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const futhark_i64_1d) -> Self
-        where
+    where
         T: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
@@ -260,23 +260,20 @@ impl Array_i64_1d {
             Ok(Array_i64_1d { ptr, ctx })
         }
     }
-    
-    pub fn to_vec(&self) -> (Vec<i64>, Vec<i64>)
-    {
+
+    pub fn to_vec(&self) -> (Vec<i64>, Vec<i64>) {
         let ctx = self.ctx;
         unsafe {
             futhark_context_sync(ctx);
             let shape = Self::shape(ctx, self.as_raw());
             let elems = shape.iter().fold(1, |acc, e| acc * e) as usize;
-            let mut buffer: Vec<i64> =
-                vec![i64::default(); elems];
+            let mut buffer: Vec<i64> = vec![i64::default(); elems];
             let cint = futhark_i64_1d::values(ctx, self.as_raw_mut(), buffer.as_mut_ptr());
             (buffer, shape.to_owned())
         }
     }
 
-    pub(crate) unsafe fn free_array(&mut self)
-    {
+    pub(crate) unsafe fn free_array(&mut self) {
         futhark_i64_1d::free(self.ctx, self.as_raw_mut());
     }
 }
@@ -295,17 +292,16 @@ pub struct Array_i64_2d {
     ctx: *mut bindings::futhark_context,
 }
 
-
 impl Array_i64_2d {
     pub(crate) unsafe fn as_raw(&self) -> *const futhark_i64_2d {
-         self.ptr
+        self.ptr
     }
 
     pub(crate) unsafe fn as_raw_mut(&self) -> *mut futhark_i64_2d {
-         self.ptr as *mut futhark_i64_2d
+        self.ptr as *mut futhark_i64_2d
     }
     pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const futhark_i64_2d) -> Self
-        where
+    where
         T: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
@@ -337,23 +333,20 @@ impl Array_i64_2d {
             Ok(Array_i64_2d { ptr, ctx })
         }
     }
-    
-    pub fn to_vec(&self) -> (Vec<i64>, Vec<i64>)
-    {
+
+    pub fn to_vec(&self) -> (Vec<i64>, Vec<i64>) {
         let ctx = self.ctx;
         unsafe {
             futhark_context_sync(ctx);
             let shape = Self::shape(ctx, self.as_raw());
             let elems = shape.iter().fold(1, |acc, e| acc * e) as usize;
-            let mut buffer: Vec<i64> =
-                vec![i64::default(); elems];
+            let mut buffer: Vec<i64> = vec![i64::default(); elems];
             let cint = futhark_i64_2d::values(ctx, self.as_raw_mut(), buffer.as_mut_ptr());
             (buffer, shape.to_owned())
         }
     }
 
-    pub(crate) unsafe fn free_array(&mut self)
-    {
+    pub(crate) unsafe fn free_array(&mut self) {
         futhark_i64_2d::free(self.ctx, self.as_raw_mut());
     }
 }
@@ -372,17 +365,16 @@ pub struct Array_u64_1d {
     ctx: *mut bindings::futhark_context,
 }
 
-
 impl Array_u64_1d {
     pub(crate) unsafe fn as_raw(&self) -> *const futhark_u64_1d {
-         self.ptr
+        self.ptr
     }
 
     pub(crate) unsafe fn as_raw_mut(&self) -> *mut futhark_u64_1d {
-         self.ptr as *mut futhark_u64_1d
+        self.ptr as *mut futhark_u64_1d
     }
     pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const futhark_u64_1d) -> Self
-        where
+    where
         T: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
@@ -414,23 +406,20 @@ impl Array_u64_1d {
             Ok(Array_u64_1d { ptr, ctx })
         }
     }
-    
-    pub fn to_vec(&self) -> (Vec<u64>, Vec<i64>)
-    {
+
+    pub fn to_vec(&self) -> (Vec<u64>, Vec<i64>) {
         let ctx = self.ctx;
         unsafe {
             futhark_context_sync(ctx);
             let shape = Self::shape(ctx, self.as_raw());
             let elems = shape.iter().fold(1, |acc, e| acc * e) as usize;
-            let mut buffer: Vec<u64> =
-                vec![u64::default(); elems];
+            let mut buffer: Vec<u64> = vec![u64::default(); elems];
             let cint = futhark_u64_1d::values(ctx, self.as_raw_mut(), buffer.as_mut_ptr());
             (buffer, shape.to_owned())
         }
     }
 
-    pub(crate) unsafe fn free_array(&mut self)
-    {
+    pub(crate) unsafe fn free_array(&mut self) {
         futhark_u64_1d::free(self.ctx, self.as_raw_mut());
     }
 }
@@ -449,17 +438,16 @@ pub struct Array_u64_2d {
     ctx: *mut bindings::futhark_context,
 }
 
-
 impl Array_u64_2d {
     pub(crate) unsafe fn as_raw(&self) -> *const futhark_u64_2d {
-         self.ptr
+        self.ptr
     }
 
     pub(crate) unsafe fn as_raw_mut(&self) -> *mut futhark_u64_2d {
-         self.ptr as *mut futhark_u64_2d
+        self.ptr as *mut futhark_u64_2d
     }
     pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const futhark_u64_2d) -> Self
-        where
+    where
         T: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
@@ -491,23 +479,20 @@ impl Array_u64_2d {
             Ok(Array_u64_2d { ptr, ctx })
         }
     }
-    
-    pub fn to_vec(&self) -> (Vec<u64>, Vec<i64>)
-    {
+
+    pub fn to_vec(&self) -> (Vec<u64>, Vec<i64>) {
         let ctx = self.ctx;
         unsafe {
             futhark_context_sync(ctx);
             let shape = Self::shape(ctx, self.as_raw());
             let elems = shape.iter().fold(1, |acc, e| acc * e) as usize;
-            let mut buffer: Vec<u64> =
-                vec![u64::default(); elems];
+            let mut buffer: Vec<u64> = vec![u64::default(); elems];
             let cint = futhark_u64_2d::values(ctx, self.as_raw_mut(), buffer.as_mut_ptr());
             (buffer, shape.to_owned())
         }
     }
 
-    pub(crate) unsafe fn free_array(&mut self)
-    {
+    pub(crate) unsafe fn free_array(&mut self) {
         futhark_u64_2d::free(self.ctx, self.as_raw_mut());
     }
 }
@@ -526,17 +511,16 @@ pub struct Array_u64_3d {
     ctx: *mut bindings::futhark_context,
 }
 
-
 impl Array_u64_3d {
     pub(crate) unsafe fn as_raw(&self) -> *const futhark_u64_3d {
-         self.ptr
+        self.ptr
     }
 
     pub(crate) unsafe fn as_raw_mut(&self) -> *mut futhark_u64_3d {
-         self.ptr as *mut futhark_u64_3d
+        self.ptr as *mut futhark_u64_3d
     }
     pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const futhark_u64_3d) -> Self
-        where
+    where
         T: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
@@ -568,23 +552,20 @@ impl Array_u64_3d {
             Ok(Array_u64_3d { ptr, ctx })
         }
     }
-    
-    pub fn to_vec(&self) -> (Vec<u64>, Vec<i64>)
-    {
+
+    pub fn to_vec(&self) -> (Vec<u64>, Vec<i64>) {
         let ctx = self.ctx;
         unsafe {
             futhark_context_sync(ctx);
             let shape = Self::shape(ctx, self.as_raw());
             let elems = shape.iter().fold(1, |acc, e| acc * e) as usize;
-            let mut buffer: Vec<u64> =
-                vec![u64::default(); elems];
+            let mut buffer: Vec<u64> = vec![u64::default(); elems];
             let cint = futhark_u64_3d::values(ctx, self.as_raw_mut(), buffer.as_mut_ptr());
             (buffer, shape.to_owned())
         }
     }
 
-    pub(crate) unsafe fn free_array(&mut self)
-    {
+    pub(crate) unsafe fn free_array(&mut self) {
         futhark_u64_3d::free(self.ctx, self.as_raw_mut());
     }
 }
@@ -596,6 +577,3 @@ impl Drop for Array_u64_3d {
         }
     }
 }
-
-
-

--- a/library/neptune-triton/src/context.rs
+++ b/library/neptune-triton/src/context.rs
@@ -32,4 +32,3 @@ impl From<FutharkContext> for *mut bindings::futhark_context {
         ctx.ptr()
     }
 }
-

--- a/library/neptune-triton/src/lib.rs
+++ b/library/neptune-triton/src/lib.rs
@@ -61,260 +61,466 @@ impl Display for FutharkError {
 }
 
 impl FutharkContext {
-pub fn build_tree8_64m(&mut self, in0: &FutharkOpaqueT864MState, in1: Array_u64_1d, ) -> Result<(Array_u64_2d)>
-{
-let ctx = self.ptr();
-unsafe{
-_build_tree8_64m(ctx, in0.as_raw_mut(), in1.as_raw_mut(), )
-}}
+    pub fn build_tree8_64m(
+        &mut self,
+        in0: &FutharkOpaqueT864MState,
+        in1: Array_u64_1d,
+    ) -> Result<(Array_u64_2d)> {
+        let ctx = self.ptr();
+        unsafe { _build_tree8_64m(ctx, in0.as_raw_mut(), in1.as_raw_mut()) }
+    }
 
-pub fn hash8(&mut self, in0: &FutharkOpaqueP8State, in1: Array_u64_1d, ) -> Result<(Array_u64_1d, FutharkOpaqueP8State)>
-{
-let ctx = self.ptr();
-unsafe{
-_hash8(ctx, in0.as_raw_mut(), in1.as_raw_mut(), )
-}}
+    pub fn hash8(
+        &mut self,
+        in0: &FutharkOpaqueP8State,
+        in1: Array_u64_1d,
+    ) -> Result<(Array_u64_1d, FutharkOpaqueP8State)> {
+        let ctx = self.ptr();
+        unsafe { _hash8(ctx, in0.as_raw_mut(), in1.as_raw_mut()) }
+    }
 
-pub fn init11(&mut self, in0: Array_u64_1d, in1: Array_u64_2d, in2: Array_u64_3d, in3: Array_u64_3d, in4: Array_u64_3d, ) -> Result<(FutharkOpaqueP11State)>
-{
-let ctx = self.ptr();
-unsafe{
-_init11(ctx, in0.as_raw_mut(), in1.as_raw_mut(), in2.as_raw_mut(), in3.as_raw_mut(), in4.as_raw_mut(), )
-}}
+    pub fn init11(
+        &mut self,
+        in0: Array_u64_1d,
+        in1: Array_u64_2d,
+        in2: Array_u64_3d,
+        in3: Array_u64_3d,
+        in4: Array_u64_3d,
+    ) -> Result<(FutharkOpaqueP11State)> {
+        let ctx = self.ptr();
+        unsafe {
+            _init11(
+                ctx,
+                in0.as_raw_mut(),
+                in1.as_raw_mut(),
+                in2.as_raw_mut(),
+                in3.as_raw_mut(),
+                in4.as_raw_mut(),
+            )
+        }
+    }
 
-pub fn init11s(&mut self, in0: Array_u64_1d, in1: Array_u64_2d, in2: Array_u64_3d, in3: Array_u64_3d, in4: Array_u64_3d, ) -> Result<(FutharkOpaqueS11State)>
-{
-let ctx = self.ptr();
-unsafe{
-_init11s(ctx, in0.as_raw_mut(), in1.as_raw_mut(), in2.as_raw_mut(), in3.as_raw_mut(), in4.as_raw_mut(), )
-}}
+    pub fn init11s(
+        &mut self,
+        in0: Array_u64_1d,
+        in1: Array_u64_2d,
+        in2: Array_u64_3d,
+        in3: Array_u64_3d,
+        in4: Array_u64_3d,
+    ) -> Result<(FutharkOpaqueS11State)> {
+        let ctx = self.ptr();
+        unsafe {
+            _init11s(
+                ctx,
+                in0.as_raw_mut(),
+                in1.as_raw_mut(),
+                in2.as_raw_mut(),
+                in3.as_raw_mut(),
+                in4.as_raw_mut(),
+            )
+        }
+    }
 
-pub fn init2(&mut self, in0: Array_u64_1d, in1: Array_u64_2d, in2: Array_u64_3d, in3: Array_u64_3d, in4: Array_u64_3d, ) -> Result<(FutharkOpaqueP2State)>
-{
-let ctx = self.ptr();
-unsafe{
-_init2(ctx, in0.as_raw_mut(), in1.as_raw_mut(), in2.as_raw_mut(), in3.as_raw_mut(), in4.as_raw_mut(), )
-}}
+    pub fn init2(
+        &mut self,
+        in0: Array_u64_1d,
+        in1: Array_u64_2d,
+        in2: Array_u64_3d,
+        in3: Array_u64_3d,
+        in4: Array_u64_3d,
+    ) -> Result<(FutharkOpaqueP2State)> {
+        let ctx = self.ptr();
+        unsafe {
+            _init2(
+                ctx,
+                in0.as_raw_mut(),
+                in1.as_raw_mut(),
+                in2.as_raw_mut(),
+                in3.as_raw_mut(),
+                in4.as_raw_mut(),
+            )
+        }
+    }
 
-pub fn init2s(&mut self, in0: Array_u64_1d, in1: Array_u64_2d, in2: Array_u64_3d, in3: Array_u64_3d, in4: Array_u64_3d, ) -> Result<(FutharkOpaqueS2State)>
-{
-let ctx = self.ptr();
-unsafe{
-_init2s(ctx, in0.as_raw_mut(), in1.as_raw_mut(), in2.as_raw_mut(), in3.as_raw_mut(), in4.as_raw_mut(), )
-}}
+    pub fn init2s(
+        &mut self,
+        in0: Array_u64_1d,
+        in1: Array_u64_2d,
+        in2: Array_u64_3d,
+        in3: Array_u64_3d,
+        in4: Array_u64_3d,
+    ) -> Result<(FutharkOpaqueS2State)> {
+        let ctx = self.ptr();
+        unsafe {
+            _init2s(
+                ctx,
+                in0.as_raw_mut(),
+                in1.as_raw_mut(),
+                in2.as_raw_mut(),
+                in3.as_raw_mut(),
+                in4.as_raw_mut(),
+            )
+        }
+    }
 
-pub fn init8(&mut self, in0: Array_u64_1d, in1: Array_u64_2d, in2: Array_u64_3d, in3: Array_u64_3d, in4: Array_u64_3d, ) -> Result<(FutharkOpaqueP8State)>
-{
-let ctx = self.ptr();
-unsafe{
-_init8(ctx, in0.as_raw_mut(), in1.as_raw_mut(), in2.as_raw_mut(), in3.as_raw_mut(), in4.as_raw_mut(), )
-}}
+    pub fn init8(
+        &mut self,
+        in0: Array_u64_1d,
+        in1: Array_u64_2d,
+        in2: Array_u64_3d,
+        in3: Array_u64_3d,
+        in4: Array_u64_3d,
+    ) -> Result<(FutharkOpaqueP8State)> {
+        let ctx = self.ptr();
+        unsafe {
+            _init8(
+                ctx,
+                in0.as_raw_mut(),
+                in1.as_raw_mut(),
+                in2.as_raw_mut(),
+                in3.as_raw_mut(),
+                in4.as_raw_mut(),
+            )
+        }
+    }
 
-pub fn init8s(&mut self, in0: Array_u64_1d, in1: Array_u64_2d, in2: Array_u64_3d, in3: Array_u64_3d, in4: Array_u64_3d, ) -> Result<(FutharkOpaqueS8State)>
-{
-let ctx = self.ptr();
-unsafe{
-_init8s(ctx, in0.as_raw_mut(), in1.as_raw_mut(), in2.as_raw_mut(), in3.as_raw_mut(), in4.as_raw_mut(), )
-}}
+    pub fn init8s(
+        &mut self,
+        in0: Array_u64_1d,
+        in1: Array_u64_2d,
+        in2: Array_u64_3d,
+        in3: Array_u64_3d,
+        in4: Array_u64_3d,
+    ) -> Result<(FutharkOpaqueS8State)> {
+        let ctx = self.ptr();
+        unsafe {
+            _init8s(
+                ctx,
+                in0.as_raw_mut(),
+                in1.as_raw_mut(),
+                in2.as_raw_mut(),
+                in3.as_raw_mut(),
+                in4.as_raw_mut(),
+            )
+        }
+    }
 
-pub fn init_t8_64m(&mut self, in0: Array_u64_1d, in1: Array_u64_2d, in2: Array_u64_3d, in3: Array_u64_3d, in4: Array_u64_3d, ) -> Result<(FutharkOpaqueT864MState)>
-{
-let ctx = self.ptr();
-unsafe{
-_init_t8_64m(ctx, in0.as_raw_mut(), in1.as_raw_mut(), in2.as_raw_mut(), in3.as_raw_mut(), in4.as_raw_mut(), )
-}}
+    pub fn init_t8_64m(
+        &mut self,
+        in0: Array_u64_1d,
+        in1: Array_u64_2d,
+        in2: Array_u64_3d,
+        in3: Array_u64_3d,
+        in4: Array_u64_3d,
+    ) -> Result<(FutharkOpaqueT864MState)> {
+        let ctx = self.ptr();
+        unsafe {
+            _init_t8_64m(
+                ctx,
+                in0.as_raw_mut(),
+                in1.as_raw_mut(),
+                in2.as_raw_mut(),
+                in3.as_raw_mut(),
+                in4.as_raw_mut(),
+            )
+        }
+    }
 
-pub fn mbatch_hash11(&mut self, in0: &FutharkOpaqueP11State, in1: Array_u64_1d, ) -> Result<(Array_u64_2d, FutharkOpaqueP11State)>
-{
-let ctx = self.ptr();
-unsafe{
-_mbatch_hash11(ctx, in0.as_raw_mut(), in1.as_raw_mut(), )
-}}
+    pub fn mbatch_hash11(
+        &mut self,
+        in0: &FutharkOpaqueP11State,
+        in1: Array_u64_1d,
+    ) -> Result<(Array_u64_2d, FutharkOpaqueP11State)> {
+        let ctx = self.ptr();
+        unsafe { _mbatch_hash11(ctx, in0.as_raw_mut(), in1.as_raw_mut()) }
+    }
 
-pub fn mbatch_hash11s(&mut self, in0: &FutharkOpaqueS11State, in1: Array_u64_1d, ) -> Result<(Array_u64_2d, FutharkOpaqueS11State)>
-{
-let ctx = self.ptr();
-unsafe{
-_mbatch_hash11s(ctx, in0.as_raw_mut(), in1.as_raw_mut(), )
-}}
+    pub fn mbatch_hash11s(
+        &mut self,
+        in0: &FutharkOpaqueS11State,
+        in1: Array_u64_1d,
+    ) -> Result<(Array_u64_2d, FutharkOpaqueS11State)> {
+        let ctx = self.ptr();
+        unsafe { _mbatch_hash11s(ctx, in0.as_raw_mut(), in1.as_raw_mut()) }
+    }
 
-pub fn mbatch_hash2(&mut self, in0: &FutharkOpaqueP2State, in1: Array_u64_1d, ) -> Result<(Array_u64_2d, FutharkOpaqueP2State)>
-{
-let ctx = self.ptr();
-unsafe{
-_mbatch_hash2(ctx, in0.as_raw_mut(), in1.as_raw_mut(), )
-}}
+    pub fn mbatch_hash2(
+        &mut self,
+        in0: &FutharkOpaqueP2State,
+        in1: Array_u64_1d,
+    ) -> Result<(Array_u64_2d, FutharkOpaqueP2State)> {
+        let ctx = self.ptr();
+        unsafe { _mbatch_hash2(ctx, in0.as_raw_mut(), in1.as_raw_mut()) }
+    }
 
-pub fn mbatch_hash2s(&mut self, in0: &FutharkOpaqueS2State, in1: Array_u64_1d, ) -> Result<(Array_u64_2d, FutharkOpaqueS2State)>
-{
-let ctx = self.ptr();
-unsafe{
-_mbatch_hash2s(ctx, in0.as_raw_mut(), in1.as_raw_mut(), )
-}}
+    pub fn mbatch_hash2s(
+        &mut self,
+        in0: &FutharkOpaqueS2State,
+        in1: Array_u64_1d,
+    ) -> Result<(Array_u64_2d, FutharkOpaqueS2State)> {
+        let ctx = self.ptr();
+        unsafe { _mbatch_hash2s(ctx, in0.as_raw_mut(), in1.as_raw_mut()) }
+    }
 
-pub fn mbatch_hash8(&mut self, in0: &FutharkOpaqueP8State, in1: Array_u64_1d, ) -> Result<(Array_u64_2d, FutharkOpaqueP8State)>
-{
-let ctx = self.ptr();
-unsafe{
-_mbatch_hash8(ctx, in0.as_raw_mut(), in1.as_raw_mut(), )
-}}
+    pub fn mbatch_hash8(
+        &mut self,
+        in0: &FutharkOpaqueP8State,
+        in1: Array_u64_1d,
+    ) -> Result<(Array_u64_2d, FutharkOpaqueP8State)> {
+        let ctx = self.ptr();
+        unsafe { _mbatch_hash8(ctx, in0.as_raw_mut(), in1.as_raw_mut()) }
+    }
 
-pub fn mbatch_hash8s(&mut self, in0: &FutharkOpaqueS8State, in1: Array_u64_1d, ) -> Result<(Array_u64_2d, FutharkOpaqueS8State)>
-{
-let ctx = self.ptr();
-unsafe{
-_mbatch_hash8s(ctx, in0.as_raw_mut(), in1.as_raw_mut(), )
-}}
+    pub fn mbatch_hash8s(
+        &mut self,
+        in0: &FutharkOpaqueS8State,
+        in1: Array_u64_1d,
+    ) -> Result<(Array_u64_2d, FutharkOpaqueS8State)> {
+        let ctx = self.ptr();
+        unsafe { _mbatch_hash8s(ctx, in0.as_raw_mut(), in1.as_raw_mut()) }
+    }
 
-pub fn simple8(&mut self, in0: i32, ) -> Result<(Array_u64_2d)>
-{
-let ctx = self.ptr();
-unsafe{
-_simple8(ctx, in0, )
-}}
-
+    pub fn simple8(&mut self, in0: i32) -> Result<(Array_u64_2d)> {
+        let ctx = self.ptr();
+        unsafe { _simple8(ctx, in0) }
+    }
 }
-unsafe fn _build_tree8_64m(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_opaque_t8_64m_state, in1: *const bindings::futhark_u64_1d, ) -> Result<(Array_u64_2d)> {
-let mut raw_out0 = std::ptr::null_mut();
+unsafe fn _build_tree8_64m(
+    ctx: *mut bindings::futhark_context,
+    in0: *const bindings::futhark_opaque_t8_64m_state,
+    in1: *const bindings::futhark_u64_1d,
+) -> Result<(Array_u64_2d)> {
+    let mut raw_out0 = std::ptr::null_mut();
 
-if bindings::futhark_entry_build_tree8_64m(ctx, &mut raw_out0, in0, in1, ) != 0 {
-return Err(FutharkError::new(ctx).into());}
-Ok((Array_u64_2d::from_ptr(ctx, raw_out0)
-))
+    if bindings::futhark_entry_build_tree8_64m(ctx, &mut raw_out0, in0, in1) != 0 {
+        return Err(FutharkError::new(ctx).into());
+    }
+    Ok((Array_u64_2d::from_ptr(ctx, raw_out0)))
 }
-unsafe fn _hash8(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_opaque_p8_state, in1: *const bindings::futhark_u64_1d, ) -> Result<(Array_u64_1d, FutharkOpaqueP8State)> {
-let mut raw_out0 = std::ptr::null_mut();
-let mut raw_out1 = std::ptr::null_mut();
+unsafe fn _hash8(
+    ctx: *mut bindings::futhark_context,
+    in0: *const bindings::futhark_opaque_p8_state,
+    in1: *const bindings::futhark_u64_1d,
+) -> Result<(Array_u64_1d, FutharkOpaqueP8State)> {
+    let mut raw_out0 = std::ptr::null_mut();
+    let mut raw_out1 = std::ptr::null_mut();
 
-if bindings::futhark_entry_hash8(ctx, &mut raw_out0, &mut raw_out1, in0, in1, ) != 0 {
-return Err(FutharkError::new(ctx).into());}
-Ok((Array_u64_1d::from_ptr(ctx, raw_out0)
-, FutharkOpaqueP8State::from_ptr(ctx, raw_out1)
-))
+    if bindings::futhark_entry_hash8(ctx, &mut raw_out0, &mut raw_out1, in0, in1) != 0 {
+        return Err(FutharkError::new(ctx).into());
+    }
+    Ok((
+        Array_u64_1d::from_ptr(ctx, raw_out0),
+        FutharkOpaqueP8State::from_ptr(ctx, raw_out1),
+    ))
 }
-unsafe fn _init11(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_u64_1d, in1: *const bindings::futhark_u64_2d, in2: *const bindings::futhark_u64_3d, in3: *const bindings::futhark_u64_3d, in4: *const bindings::futhark_u64_3d, ) -> Result<(FutharkOpaqueP11State)> {
-let mut raw_out0 = std::ptr::null_mut();
+unsafe fn _init11(
+    ctx: *mut bindings::futhark_context,
+    in0: *const bindings::futhark_u64_1d,
+    in1: *const bindings::futhark_u64_2d,
+    in2: *const bindings::futhark_u64_3d,
+    in3: *const bindings::futhark_u64_3d,
+    in4: *const bindings::futhark_u64_3d,
+) -> Result<(FutharkOpaqueP11State)> {
+    let mut raw_out0 = std::ptr::null_mut();
 
-if bindings::futhark_entry_init11(ctx, &mut raw_out0, in0, in1, in2, in3, in4, ) != 0 {
-return Err(FutharkError::new(ctx).into());}
-Ok((FutharkOpaqueP11State::from_ptr(ctx, raw_out0)
-))
+    if bindings::futhark_entry_init11(ctx, &mut raw_out0, in0, in1, in2, in3, in4) != 0 {
+        return Err(FutharkError::new(ctx).into());
+    }
+    Ok((FutharkOpaqueP11State::from_ptr(ctx, raw_out0)))
 }
-unsafe fn _init11s(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_u64_1d, in1: *const bindings::futhark_u64_2d, in2: *const bindings::futhark_u64_3d, in3: *const bindings::futhark_u64_3d, in4: *const bindings::futhark_u64_3d, ) -> Result<(FutharkOpaqueS11State)> {
-let mut raw_out0 = std::ptr::null_mut();
+unsafe fn _init11s(
+    ctx: *mut bindings::futhark_context,
+    in0: *const bindings::futhark_u64_1d,
+    in1: *const bindings::futhark_u64_2d,
+    in2: *const bindings::futhark_u64_3d,
+    in3: *const bindings::futhark_u64_3d,
+    in4: *const bindings::futhark_u64_3d,
+) -> Result<(FutharkOpaqueS11State)> {
+    let mut raw_out0 = std::ptr::null_mut();
 
-if bindings::futhark_entry_init11s(ctx, &mut raw_out0, in0, in1, in2, in3, in4, ) != 0 {
-return Err(FutharkError::new(ctx).into());}
-Ok((FutharkOpaqueS11State::from_ptr(ctx, raw_out0)
-))
+    if bindings::futhark_entry_init11s(ctx, &mut raw_out0, in0, in1, in2, in3, in4) != 0 {
+        return Err(FutharkError::new(ctx).into());
+    }
+    Ok((FutharkOpaqueS11State::from_ptr(ctx, raw_out0)))
 }
-unsafe fn _init2(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_u64_1d, in1: *const bindings::futhark_u64_2d, in2: *const bindings::futhark_u64_3d, in3: *const bindings::futhark_u64_3d, in4: *const bindings::futhark_u64_3d, ) -> Result<(FutharkOpaqueP2State)> {
-let mut raw_out0 = std::ptr::null_mut();
+unsafe fn _init2(
+    ctx: *mut bindings::futhark_context,
+    in0: *const bindings::futhark_u64_1d,
+    in1: *const bindings::futhark_u64_2d,
+    in2: *const bindings::futhark_u64_3d,
+    in3: *const bindings::futhark_u64_3d,
+    in4: *const bindings::futhark_u64_3d,
+) -> Result<(FutharkOpaqueP2State)> {
+    let mut raw_out0 = std::ptr::null_mut();
 
-if bindings::futhark_entry_init2(ctx, &mut raw_out0, in0, in1, in2, in3, in4, ) != 0 {
-return Err(FutharkError::new(ctx).into());}
-Ok((FutharkOpaqueP2State::from_ptr(ctx, raw_out0)
-))
+    if bindings::futhark_entry_init2(ctx, &mut raw_out0, in0, in1, in2, in3, in4) != 0 {
+        return Err(FutharkError::new(ctx).into());
+    }
+    Ok((FutharkOpaqueP2State::from_ptr(ctx, raw_out0)))
 }
-unsafe fn _init2s(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_u64_1d, in1: *const bindings::futhark_u64_2d, in2: *const bindings::futhark_u64_3d, in3: *const bindings::futhark_u64_3d, in4: *const bindings::futhark_u64_3d, ) -> Result<(FutharkOpaqueS2State)> {
-let mut raw_out0 = std::ptr::null_mut();
+unsafe fn _init2s(
+    ctx: *mut bindings::futhark_context,
+    in0: *const bindings::futhark_u64_1d,
+    in1: *const bindings::futhark_u64_2d,
+    in2: *const bindings::futhark_u64_3d,
+    in3: *const bindings::futhark_u64_3d,
+    in4: *const bindings::futhark_u64_3d,
+) -> Result<(FutharkOpaqueS2State)> {
+    let mut raw_out0 = std::ptr::null_mut();
 
-if bindings::futhark_entry_init2s(ctx, &mut raw_out0, in0, in1, in2, in3, in4, ) != 0 {
-return Err(FutharkError::new(ctx).into());}
-Ok((FutharkOpaqueS2State::from_ptr(ctx, raw_out0)
-))
+    if bindings::futhark_entry_init2s(ctx, &mut raw_out0, in0, in1, in2, in3, in4) != 0 {
+        return Err(FutharkError::new(ctx).into());
+    }
+    Ok((FutharkOpaqueS2State::from_ptr(ctx, raw_out0)))
 }
-unsafe fn _init8(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_u64_1d, in1: *const bindings::futhark_u64_2d, in2: *const bindings::futhark_u64_3d, in3: *const bindings::futhark_u64_3d, in4: *const bindings::futhark_u64_3d, ) -> Result<(FutharkOpaqueP8State)> {
-let mut raw_out0 = std::ptr::null_mut();
+unsafe fn _init8(
+    ctx: *mut bindings::futhark_context,
+    in0: *const bindings::futhark_u64_1d,
+    in1: *const bindings::futhark_u64_2d,
+    in2: *const bindings::futhark_u64_3d,
+    in3: *const bindings::futhark_u64_3d,
+    in4: *const bindings::futhark_u64_3d,
+) -> Result<(FutharkOpaqueP8State)> {
+    let mut raw_out0 = std::ptr::null_mut();
 
-if bindings::futhark_entry_init8(ctx, &mut raw_out0, in0, in1, in2, in3, in4, ) != 0 {
-return Err(FutharkError::new(ctx).into());}
-Ok((FutharkOpaqueP8State::from_ptr(ctx, raw_out0)
-))
+    if bindings::futhark_entry_init8(ctx, &mut raw_out0, in0, in1, in2, in3, in4) != 0 {
+        return Err(FutharkError::new(ctx).into());
+    }
+    Ok((FutharkOpaqueP8State::from_ptr(ctx, raw_out0)))
 }
-unsafe fn _init8s(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_u64_1d, in1: *const bindings::futhark_u64_2d, in2: *const bindings::futhark_u64_3d, in3: *const bindings::futhark_u64_3d, in4: *const bindings::futhark_u64_3d, ) -> Result<(FutharkOpaqueS8State)> {
-let mut raw_out0 = std::ptr::null_mut();
+unsafe fn _init8s(
+    ctx: *mut bindings::futhark_context,
+    in0: *const bindings::futhark_u64_1d,
+    in1: *const bindings::futhark_u64_2d,
+    in2: *const bindings::futhark_u64_3d,
+    in3: *const bindings::futhark_u64_3d,
+    in4: *const bindings::futhark_u64_3d,
+) -> Result<(FutharkOpaqueS8State)> {
+    let mut raw_out0 = std::ptr::null_mut();
 
-if bindings::futhark_entry_init8s(ctx, &mut raw_out0, in0, in1, in2, in3, in4, ) != 0 {
-return Err(FutharkError::new(ctx).into());}
-Ok((FutharkOpaqueS8State::from_ptr(ctx, raw_out0)
-))
+    if bindings::futhark_entry_init8s(ctx, &mut raw_out0, in0, in1, in2, in3, in4) != 0 {
+        return Err(FutharkError::new(ctx).into());
+    }
+    Ok((FutharkOpaqueS8State::from_ptr(ctx, raw_out0)))
 }
-unsafe fn _init_t8_64m(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_u64_1d, in1: *const bindings::futhark_u64_2d, in2: *const bindings::futhark_u64_3d, in3: *const bindings::futhark_u64_3d, in4: *const bindings::futhark_u64_3d, ) -> Result<(FutharkOpaqueT864MState)> {
-let mut raw_out0 = std::ptr::null_mut();
+unsafe fn _init_t8_64m(
+    ctx: *mut bindings::futhark_context,
+    in0: *const bindings::futhark_u64_1d,
+    in1: *const bindings::futhark_u64_2d,
+    in2: *const bindings::futhark_u64_3d,
+    in3: *const bindings::futhark_u64_3d,
+    in4: *const bindings::futhark_u64_3d,
+) -> Result<(FutharkOpaqueT864MState)> {
+    let mut raw_out0 = std::ptr::null_mut();
 
-if bindings::futhark_entry_init_t8_64m(ctx, &mut raw_out0, in0, in1, in2, in3, in4, ) != 0 {
-return Err(FutharkError::new(ctx).into());}
-Ok((FutharkOpaqueT864MState::from_ptr(ctx, raw_out0)
-))
+    if bindings::futhark_entry_init_t8_64m(ctx, &mut raw_out0, in0, in1, in2, in3, in4) != 0 {
+        return Err(FutharkError::new(ctx).into());
+    }
+    Ok((FutharkOpaqueT864MState::from_ptr(ctx, raw_out0)))
 }
-unsafe fn _mbatch_hash11(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_opaque_p11_state, in1: *const bindings::futhark_u64_1d, ) -> Result<(Array_u64_2d, FutharkOpaqueP11State)> {
-let mut raw_out0 = std::ptr::null_mut();
-let mut raw_out1 = std::ptr::null_mut();
+unsafe fn _mbatch_hash11(
+    ctx: *mut bindings::futhark_context,
+    in0: *const bindings::futhark_opaque_p11_state,
+    in1: *const bindings::futhark_u64_1d,
+) -> Result<(Array_u64_2d, FutharkOpaqueP11State)> {
+    let mut raw_out0 = std::ptr::null_mut();
+    let mut raw_out1 = std::ptr::null_mut();
 
-if bindings::futhark_entry_mbatch_hash11(ctx, &mut raw_out0, &mut raw_out1, in0, in1, ) != 0 {
-return Err(FutharkError::new(ctx).into());}
-Ok((Array_u64_2d::from_ptr(ctx, raw_out0)
-, FutharkOpaqueP11State::from_ptr(ctx, raw_out1)
-))
+    if bindings::futhark_entry_mbatch_hash11(ctx, &mut raw_out0, &mut raw_out1, in0, in1) != 0 {
+        return Err(FutharkError::new(ctx).into());
+    }
+    Ok((
+        Array_u64_2d::from_ptr(ctx, raw_out0),
+        FutharkOpaqueP11State::from_ptr(ctx, raw_out1),
+    ))
 }
-unsafe fn _mbatch_hash11s(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_opaque_s11_state, in1: *const bindings::futhark_u64_1d, ) -> Result<(Array_u64_2d, FutharkOpaqueS11State)> {
-let mut raw_out0 = std::ptr::null_mut();
-let mut raw_out1 = std::ptr::null_mut();
+unsafe fn _mbatch_hash11s(
+    ctx: *mut bindings::futhark_context,
+    in0: *const bindings::futhark_opaque_s11_state,
+    in1: *const bindings::futhark_u64_1d,
+) -> Result<(Array_u64_2d, FutharkOpaqueS11State)> {
+    let mut raw_out0 = std::ptr::null_mut();
+    let mut raw_out1 = std::ptr::null_mut();
 
-if bindings::futhark_entry_mbatch_hash11s(ctx, &mut raw_out0, &mut raw_out1, in0, in1, ) != 0 {
-return Err(FutharkError::new(ctx).into());}
-Ok((Array_u64_2d::from_ptr(ctx, raw_out0)
-, FutharkOpaqueS11State::from_ptr(ctx, raw_out1)
-))
+    if bindings::futhark_entry_mbatch_hash11s(ctx, &mut raw_out0, &mut raw_out1, in0, in1) != 0 {
+        return Err(FutharkError::new(ctx).into());
+    }
+    Ok((
+        Array_u64_2d::from_ptr(ctx, raw_out0),
+        FutharkOpaqueS11State::from_ptr(ctx, raw_out1),
+    ))
 }
-unsafe fn _mbatch_hash2(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_opaque_p2_state, in1: *const bindings::futhark_u64_1d, ) -> Result<(Array_u64_2d, FutharkOpaqueP2State)> {
-let mut raw_out0 = std::ptr::null_mut();
-let mut raw_out1 = std::ptr::null_mut();
+unsafe fn _mbatch_hash2(
+    ctx: *mut bindings::futhark_context,
+    in0: *const bindings::futhark_opaque_p2_state,
+    in1: *const bindings::futhark_u64_1d,
+) -> Result<(Array_u64_2d, FutharkOpaqueP2State)> {
+    let mut raw_out0 = std::ptr::null_mut();
+    let mut raw_out1 = std::ptr::null_mut();
 
-if bindings::futhark_entry_mbatch_hash2(ctx, &mut raw_out0, &mut raw_out1, in0, in1, ) != 0 {
-return Err(FutharkError::new(ctx).into());}
-Ok((Array_u64_2d::from_ptr(ctx, raw_out0)
-, FutharkOpaqueP2State::from_ptr(ctx, raw_out1)
-))
+    if bindings::futhark_entry_mbatch_hash2(ctx, &mut raw_out0, &mut raw_out1, in0, in1) != 0 {
+        return Err(FutharkError::new(ctx).into());
+    }
+    Ok((
+        Array_u64_2d::from_ptr(ctx, raw_out0),
+        FutharkOpaqueP2State::from_ptr(ctx, raw_out1),
+    ))
 }
-unsafe fn _mbatch_hash2s(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_opaque_s2_state, in1: *const bindings::futhark_u64_1d, ) -> Result<(Array_u64_2d, FutharkOpaqueS2State)> {
-let mut raw_out0 = std::ptr::null_mut();
-let mut raw_out1 = std::ptr::null_mut();
+unsafe fn _mbatch_hash2s(
+    ctx: *mut bindings::futhark_context,
+    in0: *const bindings::futhark_opaque_s2_state,
+    in1: *const bindings::futhark_u64_1d,
+) -> Result<(Array_u64_2d, FutharkOpaqueS2State)> {
+    let mut raw_out0 = std::ptr::null_mut();
+    let mut raw_out1 = std::ptr::null_mut();
 
-if bindings::futhark_entry_mbatch_hash2s(ctx, &mut raw_out0, &mut raw_out1, in0, in1, ) != 0 {
-return Err(FutharkError::new(ctx).into());}
-Ok((Array_u64_2d::from_ptr(ctx, raw_out0)
-, FutharkOpaqueS2State::from_ptr(ctx, raw_out1)
-))
+    if bindings::futhark_entry_mbatch_hash2s(ctx, &mut raw_out0, &mut raw_out1, in0, in1) != 0 {
+        return Err(FutharkError::new(ctx).into());
+    }
+    Ok((
+        Array_u64_2d::from_ptr(ctx, raw_out0),
+        FutharkOpaqueS2State::from_ptr(ctx, raw_out1),
+    ))
 }
-unsafe fn _mbatch_hash8(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_opaque_p8_state, in1: *const bindings::futhark_u64_1d, ) -> Result<(Array_u64_2d, FutharkOpaqueP8State)> {
-let mut raw_out0 = std::ptr::null_mut();
-let mut raw_out1 = std::ptr::null_mut();
+unsafe fn _mbatch_hash8(
+    ctx: *mut bindings::futhark_context,
+    in0: *const bindings::futhark_opaque_p8_state,
+    in1: *const bindings::futhark_u64_1d,
+) -> Result<(Array_u64_2d, FutharkOpaqueP8State)> {
+    let mut raw_out0 = std::ptr::null_mut();
+    let mut raw_out1 = std::ptr::null_mut();
 
-if bindings::futhark_entry_mbatch_hash8(ctx, &mut raw_out0, &mut raw_out1, in0, in1, ) != 0 {
-return Err(FutharkError::new(ctx).into());}
-Ok((Array_u64_2d::from_ptr(ctx, raw_out0)
-, FutharkOpaqueP8State::from_ptr(ctx, raw_out1)
-))
+    if bindings::futhark_entry_mbatch_hash8(ctx, &mut raw_out0, &mut raw_out1, in0, in1) != 0 {
+        return Err(FutharkError::new(ctx).into());
+    }
+    Ok((
+        Array_u64_2d::from_ptr(ctx, raw_out0),
+        FutharkOpaqueP8State::from_ptr(ctx, raw_out1),
+    ))
 }
-unsafe fn _mbatch_hash8s(ctx: *mut bindings::futhark_context, in0: *const bindings::futhark_opaque_s8_state, in1: *const bindings::futhark_u64_1d, ) -> Result<(Array_u64_2d, FutharkOpaqueS8State)> {
-let mut raw_out0 = std::ptr::null_mut();
-let mut raw_out1 = std::ptr::null_mut();
+unsafe fn _mbatch_hash8s(
+    ctx: *mut bindings::futhark_context,
+    in0: *const bindings::futhark_opaque_s8_state,
+    in1: *const bindings::futhark_u64_1d,
+) -> Result<(Array_u64_2d, FutharkOpaqueS8State)> {
+    let mut raw_out0 = std::ptr::null_mut();
+    let mut raw_out1 = std::ptr::null_mut();
 
-if bindings::futhark_entry_mbatch_hash8s(ctx, &mut raw_out0, &mut raw_out1, in0, in1, ) != 0 {
-return Err(FutharkError::new(ctx).into());}
-Ok((Array_u64_2d::from_ptr(ctx, raw_out0)
-, FutharkOpaqueS8State::from_ptr(ctx, raw_out1)
-))
+    if bindings::futhark_entry_mbatch_hash8s(ctx, &mut raw_out0, &mut raw_out1, in0, in1) != 0 {
+        return Err(FutharkError::new(ctx).into());
+    }
+    Ok((
+        Array_u64_2d::from_ptr(ctx, raw_out0),
+        FutharkOpaqueS8State::from_ptr(ctx, raw_out1),
+    ))
 }
-unsafe fn _simple8(ctx: *mut bindings::futhark_context, in0: i32, ) -> Result<(Array_u64_2d)> {
-let mut raw_out0 = std::ptr::null_mut();
+unsafe fn _simple8(ctx: *mut bindings::futhark_context, in0: i32) -> Result<(Array_u64_2d)> {
+    let mut raw_out0 = std::ptr::null_mut();
 
-if bindings::futhark_entry_simple8(ctx, &mut raw_out0, in0, ) != 0 {
-return Err(FutharkError::new(ctx).into());}
-Ok((Array_u64_2d::from_ptr(ctx, raw_out0)
-))
+    if bindings::futhark_entry_simple8(ctx, &mut raw_out0, in0) != 0 {
+        return Err(FutharkError::new(ctx).into());
+    }
+    Ok((Array_u64_2d::from_ptr(ctx, raw_out0)))
 }
 #[derive(Debug)]
 pub struct FutharkOpaqueP11State {
@@ -324,22 +530,21 @@ pub struct FutharkOpaqueP11State {
 
 impl FutharkOpaqueP11State {
     pub(crate) unsafe fn as_raw(&self) -> *const bindings::futhark_opaque_p11_state {
-         self.ptr
+        self.ptr
     }
 
     pub(crate) unsafe fn as_raw_mut(&self) -> *mut bindings::futhark_opaque_p11_state {
-         self.ptr as *mut bindings::futhark_opaque_p11_state
+        self.ptr as *mut bindings::futhark_opaque_p11_state
     }
     pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const bindings::futhark_opaque_p11_state) -> Self
-        where
+    where
         T: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         Self { ptr, ctx }
     }
 
-    pub(crate) unsafe fn free_opaque(&mut self)
-    {
+    pub(crate) unsafe fn free_opaque(&mut self) {
         bindings::futhark_free_opaque_p11_state(self.ctx, self.as_raw_mut());
     }
 }
@@ -360,22 +565,21 @@ pub struct FutharkOpaqueP2State {
 
 impl FutharkOpaqueP2State {
     pub(crate) unsafe fn as_raw(&self) -> *const bindings::futhark_opaque_p2_state {
-         self.ptr
+        self.ptr
     }
 
     pub(crate) unsafe fn as_raw_mut(&self) -> *mut bindings::futhark_opaque_p2_state {
-         self.ptr as *mut bindings::futhark_opaque_p2_state
+        self.ptr as *mut bindings::futhark_opaque_p2_state
     }
     pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const bindings::futhark_opaque_p2_state) -> Self
-        where
+    where
         T: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         Self { ptr, ctx }
     }
 
-    pub(crate) unsafe fn free_opaque(&mut self)
-    {
+    pub(crate) unsafe fn free_opaque(&mut self) {
         bindings::futhark_free_opaque_p2_state(self.ctx, self.as_raw_mut());
     }
 }
@@ -396,22 +600,21 @@ pub struct FutharkOpaqueP8State {
 
 impl FutharkOpaqueP8State {
     pub(crate) unsafe fn as_raw(&self) -> *const bindings::futhark_opaque_p8_state {
-         self.ptr
+        self.ptr
     }
 
     pub(crate) unsafe fn as_raw_mut(&self) -> *mut bindings::futhark_opaque_p8_state {
-         self.ptr as *mut bindings::futhark_opaque_p8_state
+        self.ptr as *mut bindings::futhark_opaque_p8_state
     }
     pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const bindings::futhark_opaque_p8_state) -> Self
-        where
+    where
         T: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         Self { ptr, ctx }
     }
 
-    pub(crate) unsafe fn free_opaque(&mut self)
-    {
+    pub(crate) unsafe fn free_opaque(&mut self) {
         bindings::futhark_free_opaque_p8_state(self.ctx, self.as_raw_mut());
     }
 }
@@ -432,22 +635,21 @@ pub struct FutharkOpaqueS11State {
 
 impl FutharkOpaqueS11State {
     pub(crate) unsafe fn as_raw(&self) -> *const bindings::futhark_opaque_s11_state {
-         self.ptr
+        self.ptr
     }
 
     pub(crate) unsafe fn as_raw_mut(&self) -> *mut bindings::futhark_opaque_s11_state {
-         self.ptr as *mut bindings::futhark_opaque_s11_state
+        self.ptr as *mut bindings::futhark_opaque_s11_state
     }
     pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const bindings::futhark_opaque_s11_state) -> Self
-        where
+    where
         T: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         Self { ptr, ctx }
     }
 
-    pub(crate) unsafe fn free_opaque(&mut self)
-    {
+    pub(crate) unsafe fn free_opaque(&mut self) {
         bindings::futhark_free_opaque_s11_state(self.ctx, self.as_raw_mut());
     }
 }
@@ -468,22 +670,21 @@ pub struct FutharkOpaqueS2State {
 
 impl FutharkOpaqueS2State {
     pub(crate) unsafe fn as_raw(&self) -> *const bindings::futhark_opaque_s2_state {
-         self.ptr
+        self.ptr
     }
 
     pub(crate) unsafe fn as_raw_mut(&self) -> *mut bindings::futhark_opaque_s2_state {
-         self.ptr as *mut bindings::futhark_opaque_s2_state
+        self.ptr as *mut bindings::futhark_opaque_s2_state
     }
     pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const bindings::futhark_opaque_s2_state) -> Self
-        where
+    where
         T: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         Self { ptr, ctx }
     }
 
-    pub(crate) unsafe fn free_opaque(&mut self)
-    {
+    pub(crate) unsafe fn free_opaque(&mut self) {
         bindings::futhark_free_opaque_s2_state(self.ctx, self.as_raw_mut());
     }
 }
@@ -504,22 +705,21 @@ pub struct FutharkOpaqueS8State {
 
 impl FutharkOpaqueS8State {
     pub(crate) unsafe fn as_raw(&self) -> *const bindings::futhark_opaque_s8_state {
-         self.ptr
+        self.ptr
     }
 
     pub(crate) unsafe fn as_raw_mut(&self) -> *mut bindings::futhark_opaque_s8_state {
-         self.ptr as *mut bindings::futhark_opaque_s8_state
+        self.ptr as *mut bindings::futhark_opaque_s8_state
     }
     pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const bindings::futhark_opaque_s8_state) -> Self
-        where
+    where
         T: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         Self { ptr, ctx }
     }
 
-    pub(crate) unsafe fn free_opaque(&mut self)
-    {
+    pub(crate) unsafe fn free_opaque(&mut self) {
         bindings::futhark_free_opaque_s8_state(self.ctx, self.as_raw_mut());
     }
 }
@@ -540,22 +740,24 @@ pub struct FutharkOpaqueT864MState {
 
 impl FutharkOpaqueT864MState {
     pub(crate) unsafe fn as_raw(&self) -> *const bindings::futhark_opaque_t8_64m_state {
-         self.ptr
+        self.ptr
     }
 
     pub(crate) unsafe fn as_raw_mut(&self) -> *mut bindings::futhark_opaque_t8_64m_state {
-         self.ptr as *mut bindings::futhark_opaque_t8_64m_state
+        self.ptr as *mut bindings::futhark_opaque_t8_64m_state
     }
-    pub(crate) unsafe fn from_ptr<T>(ctx: T, ptr: *const bindings::futhark_opaque_t8_64m_state) -> Self
-        where
+    pub(crate) unsafe fn from_ptr<T>(
+        ctx: T,
+        ptr: *const bindings::futhark_opaque_t8_64m_state,
+    ) -> Self
+    where
         T: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
         Self { ptr, ctx }
     }
 
-    pub(crate) unsafe fn free_opaque(&mut self)
-    {
+    pub(crate) unsafe fn free_opaque(&mut self) {
         bindings::futhark_free_opaque_t8_64m_state(self.ctx, self.as_raw_mut());
     }
 }
@@ -567,6 +769,3 @@ impl Drop for FutharkOpaqueT864MState {
         }
     }
 }
-
-
-

--- a/library/neptune-triton/src/traits.rs
+++ b/library/neptune-triton/src/traits.rs
@@ -18,4 +18,3 @@ where
         U::from_ctx(self, ctx)
     }
 }
-

--- a/library/poseidon.fut
+++ b/library/poseidon.fut
@@ -1,4 +1,4 @@
-module F = import "lib/github.com/porcuquine/fut-ff/field"
+module F = import "lib/github.com/filecoin-project/fut-ff/field"
 
 import "lib/github.com/athas/vector/vector"
 module vector_2 = cat_vector vector_1 vector_1

--- a/library/src/bin/codegen.rs
+++ b/library/src/bin/codegen.rs
@@ -11,8 +11,15 @@ fn main() {
         license: "MIT OR Apache-2.0".to_string(),
     });
 
-    set_current_dir("neptune-triton");
+    let toolchain_raw = std::fs::read_to_string("../rust-toolchain").expect(
+        "toolchain not found. codegen should be run from /neptune-triton/library directory.",
+    );
+    set_current_dir("neptune-triton").unwrap();
+
+    let toolchain = toolchain_raw[..].trim_end();
+
     Command::new("cargo")
+        .arg(format!("+{}", toolchain))
         .arg("fmt")
         .output()
         .expect("failed to format");

--- a/library/src/bin/codegen.rs
+++ b/library/src/bin/codegen.rs
@@ -6,7 +6,7 @@ fn main() {
         name: "neptune-triton".to_string(),
         file: std::path::PathBuf::from("poseidon.fut"),
         author: "porcuquine@gmail.com".to_string(),
-        version: "1.1.0".to_string(),
+        version: "1.1.1".to_string(),
         description: "GPU implementation of neptune-compatible Poseidon hashing.".to_string(),
         license: "MIT OR Apache-2.0".to_string(),
     });

--- a/library/src/bin/codegen.rs
+++ b/library/src/bin/codegen.rs
@@ -1,3 +1,6 @@
+use std::env::set_current_dir;
+use std::process::Command;
+
 fn main() {
     genfut::genfut(genfut::Opt {
         name: "neptune-triton".to_string(),
@@ -6,5 +9,11 @@ fn main() {
         version: "1.1.0".to_string(),
         description: "GPU implementation of neptune-compatible Poseidon hashing.".to_string(),
         license: "MIT OR Apache-2.0".to_string(),
-    })
+    });
+
+    set_current_dir("neptune-triton");
+    Command::new("cargo")
+        .arg("fmt")
+        .output()
+        .expect("failed to format");
 }


### PR DESCRIPTION
Upgrade to genfut 0.3.0. This should prevent some downstream build problems on older Linux machines and MacOS with an absent or non-standard OpenCL installation.

Also:
- Omit benches job from CircleCI: there are none.
- Omit clippy job from CircleCI: we need to accept genfut's output, stylish or not.
- Explicitly format the generated code.