### PR TITLE
Use Futhark v0.16.2.

### DIFF
--- a/library/neptune-triton/futhark-version.txt
+++ b/library/neptune-triton/futhark-version.txt
@@ -1,5 +1,5 @@
-Futhark 0.16.0
-git: 965e8eb (Fri Jul 3 14:53:26 2020 +0200)
+Futhark 0.16.2
+git: HEAD @ 2cd88bd (Wed Jul 15 13:40:14 2020 +0200)
 Copyright (C) DIKU, University of Copenhagen, released under the ISC license.
 This is free software: you are free to change and redistribute it.
 There is NO WARRANTY, to the extent permitted by law.


### PR DESCRIPTION
Use a released version of Futhark, [v0.16.2](https://github.com/diku-dk/futhark/releases/tag/v0.16.2) at commit [2cd88bd](https://github.com/diku-dk/futhark/commit/2cd88bd1b64c1e7d3aebcfa41c3473be845277b7).

TODO:
- [x] Check the generated code for performance regression downstream.