### PR TITLE
Use reduce_comm.

### DIFF
--- a/library/neptune-triton/lib/a.fut
+++ b/library/neptune-triton/lib/a.fut
@@ -168,7 +168,7 @@ module make_hasher (f: F.field) (p: Params): hasher = {
     Field.(s.elements[i] + s.constants.round_keys[i32.(rk_offset + i)])
 
   -- Could be more generic, but could also use a library. Just target clarity.
-  let scalar_product (a: elements) (b: elements) = Field.(reduce (+) zero (map2 (*) a b))
+  let scalar_product (a: elements) (b: elements) = Field.(reduce_comm (+) zero (map2 (*) a b))
 
   let apply_matrix (m: mat) (elts: elements): elements =
     map (scalar_product elts) (transpose m)

--- a/library/poseidon.fut
+++ b/library/poseidon.fut
@@ -168,7 +168,7 @@ module make_hasher (f: F.field) (p: Params): hasher = {
     Field.(s.elements[i] + s.constants.round_keys[i32.(rk_offset + i)])
 
   -- Could be more generic, but could also use a library. Just target clarity.
-  let scalar_product (a: elements) (b: elements) = Field.(reduce (+) zero (map2 (*) a b))
+  let scalar_product (a: elements) (b: elements) = Field.(reduce_comm (+) zero (map2 (*) a b))
 
   let apply_matrix (m: mat) (elts: elements): elements =
     map (scalar_product elts) (transpose m)


### PR DESCRIPTION
Since `(+)` is commutative, we can use `reduce_comm` instead of `reduce`. This is apparently a little bit faster in theory, although I was not able to observe a consistent improvement in benchmarks. Nevertheless, we might as well use the more specific option with expected best performance.