### PR TITLE
Use genfut 0.4.0.

### DIFF
--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/filecoin-project/neptune-triton/tree/master/lib
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-genfut = { version = "0.3.0", default-features = false, features = ["opencl"] }
+genfut = { version = "0.4.0", default-features = false, features = ["opencl"] }
 
 [[bin]]
 name="codegen"

--- a/library/neptune-triton/Cargo.toml
+++ b/library/neptune-triton/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "neptune-triton"
 description = "GPU implementation of neptune-compatible Poseidon hashing."
-version = "1.1.3"
+version = "2.0.0"
 authors = ["porcuquine@gmail.com"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/library/neptune-triton/src/arrays.rs
+++ b/library/neptune-triton/src/arrays.rs
@@ -1,6 +1,7 @@
 use crate::bindings;
 use crate::traits::*;
 use crate::{Error, Result};
+use std::os::raw::c_int;
 
 pub(crate) trait FutharkType {
     type RustType: Default;
@@ -9,10 +10,10 @@ pub(crate) trait FutharkType {
     unsafe fn shape<C>(ctx: C, ptr: *const Self) -> *const i64
     where
         C: Into<*mut bindings::futhark_context>;
-    unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType)
+    unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType) -> Result<()>
     where
         C: Into<*mut bindings::futhark_context>;
-    unsafe fn free<C>(ctx: C, ptr: *mut Self)
+    unsafe fn free<C>(ctx: C, ptr: *mut Self) -> c_int
     where
         C: Into<*mut bindings::futhark_context>;
 }
@@ -40,21 +41,25 @@ impl FutharkType for futhark_i64_1d {
         let ctx = ctx.into();
         bindings::futhark_shape_i64_1d(ctx, ptr as *mut bindings::futhark_i64_1d)
     }
-    unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType)
+    unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType) -> Result<()>
     where
         C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
-        bindings::futhark_values_i64_1d(ctx, ptr, dst);
+        let ret = bindings::futhark_values_i64_1d(ctx, ptr, dst);
+        if ret != 0 {
+            return Err(crate::FutharkError::new(ctx).into());
+        }
         // Sync the values to the array.
         bindings::futhark_context_sync(ctx);
+        Ok(())
     }
-    unsafe fn free<C>(ctx: C, ptr: *mut Self)
+    unsafe fn free<C>(ctx: C, ptr: *mut Self) -> ::std::os::raw::c_int
     where
         C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
-        bindings::futhark_free_i64_1d(ctx, ptr);
+        bindings::futhark_free_i64_1d(ctx, ptr)
     }
 }
 
@@ -79,21 +84,25 @@ impl FutharkType for futhark_i64_2d {
         let ctx = ctx.into();
         bindings::futhark_shape_i64_2d(ctx, ptr as *mut bindings::futhark_i64_2d)
     }
-    unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType)
+    unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType) -> Result<()>
     where
         C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
-        bindings::futhark_values_i64_2d(ctx, ptr, dst);
+        let ret = bindings::futhark_values_i64_2d(ctx, ptr, dst);
+        if ret != 0 {
+            return Err(crate::FutharkError::new(ctx).into());
+        }
         // Sync the values to the array.
         bindings::futhark_context_sync(ctx);
+        Ok(())
     }
-    unsafe fn free<C>(ctx: C, ptr: *mut Self)
+    unsafe fn free<C>(ctx: C, ptr: *mut Self) -> ::std::os::raw::c_int
     where
         C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
-        bindings::futhark_free_i64_2d(ctx, ptr);
+        bindings::futhark_free_i64_2d(ctx, ptr)
     }
 }
 
@@ -118,21 +127,25 @@ impl FutharkType for futhark_u64_1d {
         let ctx = ctx.into();
         bindings::futhark_shape_u64_1d(ctx, ptr as *mut bindings::futhark_u64_1d)
     }
-    unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType)
+    unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType) -> Result<()>
     where
         C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
-        bindings::futhark_values_u64_1d(ctx, ptr, dst);
+        let ret = bindings::futhark_values_u64_1d(ctx, ptr, dst);
+        if ret != 0 {
+            return Err(crate::FutharkError::new(ctx).into());
+        }
         // Sync the values to the array.
         bindings::futhark_context_sync(ctx);
+        Ok(())
     }
-    unsafe fn free<C>(ctx: C, ptr: *mut Self)
+    unsafe fn free<C>(ctx: C, ptr: *mut Self) -> ::std::os::raw::c_int
     where
         C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
-        bindings::futhark_free_u64_1d(ctx, ptr);
+        bindings::futhark_free_u64_1d(ctx, ptr)
     }
 }
 
@@ -157,21 +170,25 @@ impl FutharkType for futhark_u64_2d {
         let ctx = ctx.into();
         bindings::futhark_shape_u64_2d(ctx, ptr as *mut bindings::futhark_u64_2d)
     }
-    unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType)
+    unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType) -> Result<()>
     where
         C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
-        bindings::futhark_values_u64_2d(ctx, ptr, dst);
+        let ret = bindings::futhark_values_u64_2d(ctx, ptr, dst);
+        if ret != 0 {
+            return Err(crate::FutharkError::new(ctx).into());
+        }
         // Sync the values to the array.
         bindings::futhark_context_sync(ctx);
+        Ok(())
     }
-    unsafe fn free<C>(ctx: C, ptr: *mut Self)
+    unsafe fn free<C>(ctx: C, ptr: *mut Self) -> ::std::os::raw::c_int
     where
         C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
-        bindings::futhark_free_u64_2d(ctx, ptr);
+        bindings::futhark_free_u64_2d(ctx, ptr)
     }
 }
 
@@ -196,21 +213,25 @@ impl FutharkType for futhark_u64_3d {
         let ctx = ctx.into();
         bindings::futhark_shape_u64_3d(ctx, ptr as *mut bindings::futhark_u64_3d)
     }
-    unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType)
+    unsafe fn values<C>(ctx: C, ptr: *mut Self, dst: *mut Self::RustType) -> Result<()>
     where
         C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
-        bindings::futhark_values_u64_3d(ctx, ptr, dst);
+        let ret = bindings::futhark_values_u64_3d(ctx, ptr, dst);
+        if ret != 0 {
+            return Err(crate::FutharkError::new(ctx).into());
+        }
         // Sync the values to the array.
         bindings::futhark_context_sync(ctx);
+        Ok(())
     }
-    unsafe fn free<C>(ctx: C, ptr: *mut Self)
+    unsafe fn free<C>(ctx: C, ptr: *mut Self) -> ::std::os::raw::c_int
     where
         C: Into<*mut bindings::futhark_context>,
     {
         let ctx = ctx.into();
-        bindings::futhark_free_u64_3d(ctx, ptr);
+        bindings::futhark_free_u64_3d(ctx, ptr)
     }
 }
 #[derive(Debug)]
@@ -261,20 +282,25 @@ impl Array_i64_1d {
         }
     }
 
-    pub fn to_vec(&self) -> (Vec<i64>, Vec<i64>) {
+    pub fn to_vec(&self) -> Result<(Vec<i64>, Vec<i64>)> {
         let ctx = self.ctx;
         unsafe {
             futhark_context_sync(ctx);
             let shape = Self::shape(ctx, self.as_raw());
             let elems = shape.iter().fold(1, |acc, e| acc * e) as usize;
             let mut buffer: Vec<i64> = vec![i64::default(); elems];
-            let cint = futhark_i64_1d::values(ctx, self.as_raw_mut(), buffer.as_mut_ptr());
-            (buffer, shape.to_owned())
+            let cint = futhark_i64_1d::values(ctx, self.as_raw_mut(), buffer.as_mut_ptr())?;
+            Ok((buffer, shape.to_owned()))
         }
     }
 
     pub(crate) unsafe fn free_array(&mut self) {
-        futhark_i64_1d::free(self.ctx, self.as_raw_mut());
+        if futhark_i64_1d::free(self.ctx, self.as_raw_mut()) != 0 {
+            panic!(
+                "Deallocation of object failed, this should not happen \
+                    outside of compiler bugs and driver or hardware malfunction."
+            );
+        }
     }
 }
 
@@ -334,20 +360,25 @@ impl Array_i64_2d {
         }
     }
 
-    pub fn to_vec(&self) -> (Vec<i64>, Vec<i64>) {
+    pub fn to_vec(&self) -> Result<(Vec<i64>, Vec<i64>)> {
         let ctx = self.ctx;
         unsafe {
             futhark_context_sync(ctx);
             let shape = Self::shape(ctx, self.as_raw());
             let elems = shape.iter().fold(1, |acc, e| acc * e) as usize;
             let mut buffer: Vec<i64> = vec![i64::default(); elems];
-            let cint = futhark_i64_2d::values(ctx, self.as_raw_mut(), buffer.as_mut_ptr());
-            (buffer, shape.to_owned())
+            let cint = futhark_i64_2d::values(ctx, self.as_raw_mut(), buffer.as_mut_ptr())?;
+            Ok((buffer, shape.to_owned()))
         }
     }
 
     pub(crate) unsafe fn free_array(&mut self) {
-        futhark_i64_2d::free(self.ctx, self.as_raw_mut());
+        if futhark_i64_2d::free(self.ctx, self.as_raw_mut()) != 0 {
+            panic!(
+                "Deallocation of object failed, this should not happen \
+                    outside of compiler bugs and driver or hardware malfunction."
+            );
+        }
     }
 }
 
@@ -407,20 +438,25 @@ impl Array_u64_1d {
         }
     }
 
-    pub fn to_vec(&self) -> (Vec<u64>, Vec<i64>) {
+    pub fn to_vec(&self) -> Result<(Vec<u64>, Vec<i64>)> {
         let ctx = self.ctx;
         unsafe {
             futhark_context_sync(ctx);
             let shape = Self::shape(ctx, self.as_raw());
             let elems = shape.iter().fold(1, |acc, e| acc * e) as usize;
             let mut buffer: Vec<u64> = vec![u64::default(); elems];
-            let cint = futhark_u64_1d::values(ctx, self.as_raw_mut(), buffer.as_mut_ptr());
-            (buffer, shape.to_owned())
+            let cint = futhark_u64_1d::values(ctx, self.as_raw_mut(), buffer.as_mut_ptr())?;
+            Ok((buffer, shape.to_owned()))
         }
     }
 
     pub(crate) unsafe fn free_array(&mut self) {
-        futhark_u64_1d::free(self.ctx, self.as_raw_mut());
+        if futhark_u64_1d::free(self.ctx, self.as_raw_mut()) != 0 {
+            panic!(
+                "Deallocation of object failed, this should not happen \
+                    outside of compiler bugs and driver or hardware malfunction."
+            );
+        }
     }
 }
 
@@ -480,20 +516,25 @@ impl Array_u64_2d {
         }
     }
 
-    pub fn to_vec(&self) -> (Vec<u64>, Vec<i64>) {
+    pub fn to_vec(&self) -> Result<(Vec<u64>, Vec<i64>)> {
         let ctx = self.ctx;
         unsafe {
             futhark_context_sync(ctx);
             let shape = Self::shape(ctx, self.as_raw());
             let elems = shape.iter().fold(1, |acc, e| acc * e) as usize;
             let mut buffer: Vec<u64> = vec![u64::default(); elems];
-            let cint = futhark_u64_2d::values(ctx, self.as_raw_mut(), buffer.as_mut_ptr());
-            (buffer, shape.to_owned())
+            let cint = futhark_u64_2d::values(ctx, self.as_raw_mut(), buffer.as_mut_ptr())?;
+            Ok((buffer, shape.to_owned()))
         }
     }
 
     pub(crate) unsafe fn free_array(&mut self) {
-        futhark_u64_2d::free(self.ctx, self.as_raw_mut());
+        if futhark_u64_2d::free(self.ctx, self.as_raw_mut()) != 0 {
+            panic!(
+                "Deallocation of object failed, this should not happen \
+                    outside of compiler bugs and driver or hardware malfunction."
+            );
+        }
     }
 }
 
@@ -553,20 +594,25 @@ impl Array_u64_3d {
         }
     }
 
-    pub fn to_vec(&self) -> (Vec<u64>, Vec<i64>) {
+    pub fn to_vec(&self) -> Result<(Vec<u64>, Vec<i64>)> {
         let ctx = self.ctx;
         unsafe {
             futhark_context_sync(ctx);
             let shape = Self::shape(ctx, self.as_raw());
             let elems = shape.iter().fold(1, |acc, e| acc * e) as usize;
             let mut buffer: Vec<u64> = vec![u64::default(); elems];
-            let cint = futhark_u64_3d::values(ctx, self.as_raw_mut(), buffer.as_mut_ptr());
-            (buffer, shape.to_owned())
+            let cint = futhark_u64_3d::values(ctx, self.as_raw_mut(), buffer.as_mut_ptr())?;
+            Ok((buffer, shape.to_owned()))
         }
     }
 
     pub(crate) unsafe fn free_array(&mut self) {
-        futhark_u64_3d::free(self.ctx, self.as_raw_mut());
+        if futhark_u64_3d::free(self.ctx, self.as_raw_mut()) != 0 {
+            panic!(
+                "Deallocation of object failed, this should not happen \
+                    outside of compiler bugs and driver or hardware malfunction."
+            );
+        }
     }
 }
 

--- a/library/neptune-triton/src/lib.rs
+++ b/library/neptune-triton/src/lib.rs
@@ -60,6 +60,21 @@ impl Display for FutharkError {
     }
 }
 
+impl std::error::Error for FutharkError {}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Error::FutharkError(ferr) => write!(f, "{}", ferr),
+            Error::SizeMismatch(actual, expected) => {
+                write!(f, "Size was: {}, expected: {}.", actual, expected)
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
 impl FutharkContext {
     pub fn build_tree8_64m(
         &mut self,
@@ -545,7 +560,12 @@ impl FutharkOpaqueP11State {
     }
 
     pub(crate) unsafe fn free_opaque(&mut self) {
-        bindings::futhark_free_opaque_p11_state(self.ctx, self.as_raw_mut());
+        if bindings::futhark_free_opaque_p11_state(self.ctx, self.as_raw_mut()) != 0 {
+            panic!(
+                "Deallocation of object failed, this should not happen \
+                    outside of compiler bugs and driver or hardware malfunction."
+            );
+        }
     }
 }
 
@@ -580,7 +600,12 @@ impl FutharkOpaqueP2State {
     }
 
     pub(crate) unsafe fn free_opaque(&mut self) {
-        bindings::futhark_free_opaque_p2_state(self.ctx, self.as_raw_mut());
+        if bindings::futhark_free_opaque_p2_state(self.ctx, self.as_raw_mut()) != 0 {
+            panic!(
+                "Deallocation of object failed, this should not happen \
+                    outside of compiler bugs and driver or hardware malfunction."
+            );
+        }
     }
 }
 
@@ -615,7 +640,12 @@ impl FutharkOpaqueP8State {
     }
 
     pub(crate) unsafe fn free_opaque(&mut self) {
-        bindings::futhark_free_opaque_p8_state(self.ctx, self.as_raw_mut());
+        if bindings::futhark_free_opaque_p8_state(self.ctx, self.as_raw_mut()) != 0 {
+            panic!(
+                "Deallocation of object failed, this should not happen \
+                    outside of compiler bugs and driver or hardware malfunction."
+            );
+        }
     }
 }
 
@@ -650,7 +680,12 @@ impl FutharkOpaqueS11State {
     }
 
     pub(crate) unsafe fn free_opaque(&mut self) {
-        bindings::futhark_free_opaque_s11_state(self.ctx, self.as_raw_mut());
+        if bindings::futhark_free_opaque_s11_state(self.ctx, self.as_raw_mut()) != 0 {
+            panic!(
+                "Deallocation of object failed, this should not happen \
+                    outside of compiler bugs and driver or hardware malfunction."
+            );
+        }
     }
 }
 
@@ -685,7 +720,12 @@ impl FutharkOpaqueS2State {
     }
 
     pub(crate) unsafe fn free_opaque(&mut self) {
-        bindings::futhark_free_opaque_s2_state(self.ctx, self.as_raw_mut());
+        if bindings::futhark_free_opaque_s2_state(self.ctx, self.as_raw_mut()) != 0 {
+            panic!(
+                "Deallocation of object failed, this should not happen \
+                    outside of compiler bugs and driver or hardware malfunction."
+            );
+        }
     }
 }
 
@@ -720,7 +760,12 @@ impl FutharkOpaqueS8State {
     }
 
     pub(crate) unsafe fn free_opaque(&mut self) {
-        bindings::futhark_free_opaque_s8_state(self.ctx, self.as_raw_mut());
+        if bindings::futhark_free_opaque_s8_state(self.ctx, self.as_raw_mut()) != 0 {
+            panic!(
+                "Deallocation of object failed, this should not happen \
+                    outside of compiler bugs and driver or hardware malfunction."
+            );
+        }
     }
 }
 
@@ -758,7 +803,12 @@ impl FutharkOpaqueT864MState {
     }
 
     pub(crate) unsafe fn free_opaque(&mut self) {
-        bindings::futhark_free_opaque_t8_64m_state(self.ctx, self.as_raw_mut());
+        if bindings::futhark_free_opaque_t8_64m_state(self.ctx, self.as_raw_mut()) != 0 {
+            panic!(
+                "Deallocation of object failed, this should not happen \
+                    outside of compiler bugs and driver or hardware malfunction."
+            );
+        }
     }
 }
 

--- a/library/src/bin/codegen.rs
+++ b/library/src/bin/codegen.rs
@@ -6,7 +6,7 @@ fn main() {
         name: "neptune-triton".to_string(),
         file: std::path::PathBuf::from("poseidon.fut"),
         author: "porcuquine@gmail.com".to_string(),
-        version: "1.1.3".to_string(),
+        version: "2.0.0".to_string(),
         description: "GPU implementation of neptune-compatible Poseidon hashing.".to_string(),
         license: "MIT OR Apache-2.0".to_string(),
     });


### PR DESCRIPTION
Use genfut 0.4.0, especially in order to get a fix to the remaining medium severity issue from the security audit.

That is fixed here: https://github.com/Erk-/genfut/pull/22
And we also get: https://github.com/Erk-/genfut/pull/24
And: https://github.com/Erk-/genfut/pull/21