### PR TITLE
Build and link on macos via genfut 0.4.1.

### DIFF
--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -17,10 +17,10 @@ pub fn main() -> Result<(), Error> {
 }
 
 fn simple_8(n: i32) -> Result<(Vec<u64>, usize), Error> {
-    let mut ctx = FutharkContext::new();
+    let mut ctx = FutharkContext::new()?;
 
     let res_arr = ctx.simple8(n)?;
-    let (vec, shape) = res_arr.to_vec();
+    let (vec, shape) = res_arr.to_vec()?;
     assert_eq!(n as i64, shape[0]);
     let chunk_size = shape[1] as usize;
 

--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/filecoin-project/neptune-triton/tree/master/lib
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-genfut = { version = "0.4.0", default-features = false, features = ["opencl"] }
+genfut = { version = "=0.4.1", default-features = false, features = ["opencl"] }
 
 [[bin]]
 name="codegen"

--- a/library/neptune-triton/Cargo.toml
+++ b/library/neptune-triton/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "neptune-triton"
 description = "GPU implementation of neptune-compatible Poseidon hashing."
-version = "2.0.0"
+version = "2.1.0"
 authors = ["porcuquine@gmail.com"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/library/neptune-triton/build.rs
+++ b/library/neptune-triton/build.rs
@@ -40,10 +40,19 @@ fn main() {
                 .file("./lib/a.c")
                 .flag("-fPIC")
                 .flag("-std=c99")
-                .flag("-lOpenCL")
                 .shared_flag(true)
                 .compile("a");
             println!("cargo:rustc-link-lib=dylib=OpenCL");
+        }
+        #[cfg(target_os = "macos")]
+        {
+            cc::Build::new()
+                .file("./lib/a.c")
+                .flag("-fPIC")
+                .flag("-std=c99")
+                .shared_flag(true)
+                .compile("a");
+            println!("cargo:rustc-link-lib=framework=OpenCL");
         }
     }
 }

--- a/library/src/bin/codegen.rs
+++ b/library/src/bin/codegen.rs
@@ -6,7 +6,7 @@ fn main() {
         name: "neptune-triton".to_string(),
         file: std::path::PathBuf::from("poseidon.fut"),
         author: "porcuquine@gmail.com".to_string(),
-        version: "2.0.0".to_string(),
+        version: "2.1.0".to_string(),
         description: "GPU implementation of neptune-compatible Poseidon hashing.".to_string(),
         license: "MIT OR Apache-2.0".to_string(),
     });


### PR DESCRIPTION
Use genfut 0.4.1, which now generates a `build.rs` which succeeds on macos.

Also, incidentally: update the example, which had fallen out of date and did not build.